### PR TITLE
Kevin/neyn 1528 viewer context not returning for cast interaction v4

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -667,16 +667,10 @@ components:
           type: integer
           format: int32
     CastWithInteractions:
-      type: object
-      required:
-        - reactions
-        - replies
-        - thread_hash
-        - mentioned_profiles
       allOf:
         - $ref: '#/components/schemas/Cast'
         - type: object
-        required:
+        - required:
           - reactions
           - replies
           - thread_hash

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -676,6 +676,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/Cast'
         - type: object
+        required:
+          - reactions
+          - replies
+          - thread_hash
+          - mentioned_profiles
           properties:
             frames:
               type: array


### PR DESCRIPTION
reverts the CastWithInteraction object back to what it was before

