### PR TITLE
Doc changes for adding channel_dehydrated object back to v2/farcaster/cast API responses [NEYN-1258]

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -849,6 +849,16 @@ components:
         count:
           type: integer
           format: int32
+    ChannelOrDehydratedChannel:
+      oneOf:
+        - $ref: '#/components/schemas/Channel'
+        - $ref: '#/components/schemas/DehydratedChannel'
+        - type: 'null'
+      discriminator:
+        propertyName: type
+        mapping:
+          channel: '#/components/schemas/Channel'
+          dehydratedChannel: '#/components/schemas/DehydratedChannel'
     CastWithInteractions:
       allOf:
         - $ref: "#/components/schemas/Cast"
@@ -875,7 +885,7 @@ components:
               items:
                 $ref: "#/components/schemas/User"
             channel:
-              $ref: "#/components/schemas/Channel"
+              $ref: "#/components/schemas/ChannelOrDehydratedChannel"
             viewer_context:
               $ref: "#/components/schemas/CastViewerContext"
     CastWithInteractionsAndConversations:
@@ -1084,6 +1094,23 @@ components:
       properties:
         cast:
           $ref: "#/components/schemas/CastWithInteractions"
+    DehydratedChannel:
+      type: object
+      required:
+        - id
+        - name
+        - object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        object:
+          type: string
+          enum:
+            - channel_dehydrated
+        image_url:
+          type: string
     Channel:
       type: object
       required:


### PR DESCRIPTION
Reapply "Kevin/neyn 1274 add oas to update to have one of dehydrated or full (#89)"

This reverts commit 00e2097c1bd317b86fc72fc3ff34f417fe536bb6.

Doc changes for https://github.com/neynarxyz/api/pull/509