### PR TITLE
Reapply "Doc changes for adding channel_dehydrated object back to v2/…

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -849,6 +849,16 @@ components:
         count:
           type: integer
           format: int32
+    ChannelOrDehydratedChannel:
+      oneOf:
+        - $ref: '#/components/schemas/Channel'
+        - $ref: '#/components/schemas/DehydratedChannel'
+        - type: 'null'
+      discriminator:
+        propertyName: type
+        mapping:
+          channel: '#/components/schemas/Channel'
+          dehydratedChannel: '#/components/schemas/DehydratedChannel'
     CastWithInteractions:
       allOf:
         - $ref: "#/components/schemas/Cast"
@@ -875,7 +885,7 @@ components:
               items:
                 $ref: "#/components/schemas/User"
             channel:
-              $ref: "#/components/schemas/Channel"
+              $ref: "#/components/schemas/ChannelOrDehydratedChannel"
             viewer_context:
               $ref: "#/components/schemas/CastViewerContext"
     CastWithInteractionsAndConversations:
@@ -1086,6 +1096,23 @@ components:
       properties:
         cast:
           $ref: "#/components/schemas/CastWithInteractions"
+    DehydratedChannel:
+      type: object
+      required:
+        - id
+        - name
+        - object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        object:
+          type: string
+          enum:
+            - channel_dehydrated
+        image_url:
+          type: string
     Channel:
       type: object
       required:


### PR DESCRIPTION
…farcaster/cast API responses [NEYN-1258] (#140)"

This reverts commit 97d6b312965a831b41e1ea6c60fcd82d4389a8ba.

Let's not merge this until after https://github.com/neynarxyz/api/pull/512 is confirmed good or not, so we don't have to revert prematurely again. 