### PR TITLE
docs: remove is_priority from notifications API docs

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1895,9 +1895,6 @@ components:
         - title
         - index
         - action_type
-    isPriority:
-      type: boolean
-      default: true
     NeynarPageInput:
       type: object
       properties:
@@ -4639,11 +4636,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: is_priority
-          in: query
-          schema:
-            $ref: "#/components/schemas/isPriority"
-          required: false
       responses:
         "200":
           description: Successful response
@@ -4684,11 +4676,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: is_priority
-          in: query
-          schema:
-            $ref: "#/components/schemas/isPriority"
-          required: false
       responses:
         "200":
           description: Successful response
@@ -4729,11 +4716,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: is_priority
-          in: query
-          schema:
-            $ref: "#/components/schemas/isPriority"
-          required: false
       responses:
         "200":
           description: Successful response


### PR DESCRIPTION
This PR removed the `is_priority` parameter from all 3 `notifications` endpoint docs.