### PR TITLE
docs: add docs for /v2/farcaster/feed/user/recent endpoint

### DIFF
--- a/src/v1/spec.yaml
+++ b/src/v1/spec.yaml
@@ -1053,7 +1053,8 @@ paths:
       tags:
         - Cast
       summary: Retrieve casts for a given user
-      description: Gets the most recent casts for a user
+      description: Gets the most recent casts for a user; use /v2/farcaster/feed/user/recent instead
+      deprecated: true
       externalDocs:
         url: https://docs.neynar.com/reference/casts-v1
       operationId: casts

--- a/src/v1/spec.yaml
+++ b/src/v1/spec.yaml
@@ -1052,8 +1052,8 @@ paths:
     get:
       tags:
         - Cast
-      summary: Retrieve casts for a given user
-      description: Gets the most recent casts for a user; use /v2/farcaster/feed/user/recent instead
+      summary: DEPRECATED - Retrieve casts for a given user
+      description: Now deprecated, use [/v2/farcaster/feed/user/recent]( https://docs.neynar.com/reference/feed-user-recent) instead
       deprecated: true
       externalDocs:
         url: https://docs.neynar.com/reference/casts-v1

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -4245,11 +4245,11 @@ paths:
           $ref: "#/components/responses/400Response"
   /farcaster/feed/user/casts:
     get:
-      summary: Retrieve recent casts for a user
-      description: Retrieve recent casts for a given user FID in reverse chronological order. Also allows filtering by parent_url and channel
+      summary: Retrieve casts for a user
+      description: Retrieve casts for a given user FID in reverse chronological order. Also allows filtering by parent_url and channel
       externalDocs:
-        url: https://docs.neynar.com/reference/feed-user-recent
-      operationId: feed-user-recent
+        url: https://docs.neynar.com/reference/feed-user-casts
+      operationId: feed-user-casts
       tags:
         - Feed
       parameters:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -4243,10 +4243,10 @@ paths:
                 $ref: "#/components/schemas/FeedResponse"
         "400":
           $ref: "#/components/responses/400Response"
-  /farcaster/feed/user/recent:
+  /farcaster/feed/user/casts:
     get:
       summary: Retrieve recent casts for a user
-      description: Retrieve recent casts for a given user FID; also allows filtering by parent_url and channel
+      description: Retrieve recent casts for a given user FID in reverse chronological order. Also allows filtering by parent_url and channel
       externalDocs:
         url: https://docs.neynar.com/reference/feed-user-recent
       operationId: feed-user-recent

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -4243,6 +4243,68 @@ paths:
                 $ref: "#/components/schemas/FeedResponse"
         "400":
           $ref: "#/components/responses/400Response"
+  /farcaster/feed/user/recent:
+    get:
+      summary: Retrieve recent casts for a user
+      description: Retrieve recent casts for a given user FID; also allows filtering by parent_url and channel
+      externalDocs:
+        url: https://docs.neynar.com/reference/feed-user-recent
+      operationId: feed-user-recent
+      tags:
+        - Feed
+      parameters:
+        - $ref: "#/components/parameters/ApiKey"
+        - name: fid
+          in: query
+          required: true
+          example: 194
+          schema:
+            $ref: "#/components/schemas/Fid"
+          description: FID of user whose recent casts you want to fetch
+        - name: viewer_fid
+          in: query
+          required: false
+          example: 3
+          schema:
+            $ref: "#/components/schemas/Fid"
+          description: FID of the user viewing the feed 
+        - name: limit
+          in: query
+          required: false
+          description: Number of results to retrieve (default 25, max 50)
+          schema:
+            type: integer
+            default: 25
+            minimum: 1
+            maximum: 50
+        - name: cursor
+          in: query
+          description: Pagination cursor
+          schema:
+            type: string
+        - name: parent_url
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Parent URL to filter the feed; mutually exclusive with channel_id
+        - name: channel_id
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Channel ID to filter the feed; mutually exclusive with parent_url
+      responses:
+        "200":
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeedResponse"
+        "400":
+          $ref: "#/components/responses/400Response"
+        "500":
+          $ref: "#/components/responses/500Response"
   /farcaster/frame:
     get:
       tags:


### PR DESCRIPTION
This PR adds docs for the new `/v2/farcaster/feed/user/recent` endpoint
