### PR TITLE
docs: redirect /v1/casts to the correct v2 endpoint

### DIFF
--- a/src/v1/spec.yaml
+++ b/src/v1/spec.yaml
@@ -1053,7 +1053,7 @@ paths:
       tags:
         - Cast
       summary: DEPRECATED - Retrieve casts for a given user
-      description: Now deprecated, use [/v2/farcaster/feed/user/recent]( https://docs.neynar.com/reference/feed-user-recent) instead
+      description: Now deprecated, use [/v2/farcaster/feed/user/casts](https://docs.neynar.com/reference/feed-user-casts) instead
       deprecated: true
       externalDocs:
         url: https://docs.neynar.com/reference/casts-v1


### PR DESCRIPTION
fast follow to https://github.com/neynarxyz/OAS/pull/171

Corrects an issue where the v1 deprecation redirect was pointing to the wrong URL. It now points correctly to https://docs.neynar.com/reference/feed-user-casts