### PR TITLE
docs: add 'include_replies' field to  endpoint

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -4282,6 +4282,13 @@ paths:
           description: Pagination cursor
           schema:
             type: string
+        - name: include_replies
+          in: query
+          required: false
+          description: Include replies in the response, true by default
+          schema:
+            type: boolean
+            default: true
         - name: parent_url
           in: query
           required: false


### PR DESCRIPTION
Adds `include_replies` flag to `/v2/farcaster/feed/user/casts` endpoint
