### PR TITLE
docs: add docs for `/v2/farcaster/user/power-lite` endpoint

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -3158,6 +3158,26 @@ paths:
                 $ref: "#/components/schemas/UsersResponse"
         "400":
           $ref: "#/components/responses/400Response"
+  /farcaster/user/power-lite:
+    get:
+      tags:
+        - User
+      summary: Fetch power user FIDs
+      description: Fetches power users and respond in a backwards compatible format to Warpcast's deprecated power badge endpoint.
+      externalDocs:
+        url: https://docs.neynar.com/reference/user-power-lite
+      operationId: power-users-lite
+      responses:
+        "200":
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsersResponse"
+        "400":
+          $ref: "#/components/responses/400Response"
+        "500":
+          $ref: "#/components/responses/500Response"
   /farcaster/user/active:
     get:
       tags:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -3158,7 +3158,7 @@ paths:
                 $ref: "#/components/schemas/UsersResponse"
         "400":
           $ref: "#/components/responses/400Response"
-  /farcaster/user/power-lite:
+  /farcaster/user/power_lite:
     get:
       tags:
         - User

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -3166,7 +3166,7 @@ paths:
       description: Fetches power users and respond in a backwards compatible format to Warpcast's deprecated power badge endpoint.
       externalDocs:
         url: https://docs.neynar.com/reference/user-power-lite
-      operationId: power-users-lite
+      operationId: user-power-lite
       responses:
         "200":
           description: Successful operation.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -3167,6 +3167,8 @@ paths:
       externalDocs:
         url: https://docs.neynar.com/reference/user-power-lite
       operationId: user-power-lite
+      parameters:
+        - $ref: "#/components/parameters/ApiKey"
       responses:
         "200":
           description: Successful operation.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -3173,7 +3173,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UsersResponse"
+                - type: object
+                required:
+                  - fids
+                properties:
+                  fids:
+                    type: array
+                    description: An array of all FIDs with the power badge
+                    items:
+                      $ref: "#/components/schemas/Fid"
         "400":
           $ref: "#/components/responses/400Response"
         "500":

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -2753,6 +2753,23 @@ components:
         - expires_at
         - subscribed_at
         - tier
+    Fids:
+      type: array
+      items:
+        $ref: "#/components/schemas/Fid"
+      description: List of FIDs
+    UserPowerLiteResponse:
+      type: object
+      required:
+        - result
+      properties:
+        result:
+          type: object
+          required:
+            - fids
+          properties:
+            fids:
+              $ref: "#/components/schemas/Fids"
   parameters:
     ApiKey:
       name: api_key
@@ -3175,15 +3192,7 @@ paths:
           content:
             application/json:
               schema:
-                - type: object
-                required:
-                  - fids
-                properties:
-                  fids:
-                    type: array
-                    description: An array of all FIDs with the power badge
-                    items:
-                      $ref: "#/components/schemas/Fid"
+                $ref: "#/components/schemas/UserPowerLiteResponse"
         "400":
           $ref: "#/components/responses/400Response"
         "500":


### PR DESCRIPTION
Introducing a warpcast power user backwards compatible endpoint that returns a list of FIDs. No pagination, no frills, no response changes. Just a plug & play replacement for the now deprecated [`https://api.warpcast.com/v2/power-badge-users` endpoint](https://docs.farcaster.xyz/reference/warpcast/api#get-all-power-badge-users)