### PR TITLE
different notification enums for input and output

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1991,14 +1991,6 @@ components:
             $ref: "#/components/schemas/Notification"
         next:
           $ref: "#/components/schemas/NextCursor"
-    NotificationType:
-      type: string
-      enum:
-        - follows
-        - recasts
-        - likes
-        - mentions
-        - replies
     Notification:
       type: object
       required:
@@ -2012,7 +2004,13 @@ components:
           type: string
           format: date-time
         type:
-          $ref: "#/components/schemas/NotificationType"
+          type: string
+          enum:
+            - follows
+            - recasts
+            - likes
+            - mention
+            - reply
         follows:
           type: array
           items:
@@ -5388,7 +5386,13 @@ paths:
           in: query
           required: false
           schema:
-            $ref: "#/components/schemas/NotificationType"
+            type: string
+            enum:
+              - follows
+              - recasts
+              - likes
+              - mentions
+              - replies
           description: Notification type to fetch.
         - name: cursor
           in: query


### PR DESCRIPTION
For specifying the type that is wanted from the notifications endpoint, all valid options are plural: follows, recasts, likes, mentions, replies.

For the output provided by the notifications endpoint, some are plural: follows, recasts, likes. The others are singular: mention, reply.