### PR TITLE
add: ensure `x-api-key` header is properly set for hub rest api docs

### DIFF
--- a/src/hub-rest-api/spec.yaml
+++ b/src/hub-rest-api/spec.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  title: Raw Farcaster Hub API Test
+  title: Raw Farcaster Hub API
   version: "1.0"
   description: >
     Perform basic queries of Farcaster state via the REST API of a Farcaster hub.

--- a/src/hub-rest-api/spec.yaml
+++ b/src/hub-rest-api/spec.yaml
@@ -1,12 +1,15 @@
 openapi: 3.0.1
 info:
-  title: Raw Farcaster Hub API
+  title: Raw Farcaster Hub API Test
   version: "1.0"
   description: >
     Perform basic queries of Farcaster state via the REST API of a Farcaster hub.
     See the [Farcaster docs](https://www.thehubble.xyz/docs/httpapi/httpapi.html) for more details.
 servers:
 - url: https://hub-api.neynar.com
+
+security:
+  - ApiKeyAuth: []
 
 paths:
   /v1/info:
@@ -887,7 +890,8 @@ components:
       type: apiKey
       in: header
       name: x-api-key
-      description: "API key to authorize requests. Example: 'NEYNAR_DOCS'"
+      description: "API key to authorize requests"
+      x-example: "NEYNAR_API_DOCS"
   parameters:
     pageSize:
       name: pageSize


### PR DESCRIPTION
ensures a proper `x-api-key` header is set for the Raw Farcaster Hub API documentation 