### PR TITLE
fix: uses  for example api key

### DIFF
--- a/src/v1/spec.yaml
+++ b/src/v1/spec.yaml
@@ -15,7 +15,7 @@ components:
         in: header
         name: x-api-key
         description: "API key to authorize requests"
-        x-example: "NEYNAR_API_DOCS"
+        x-default: "NEYNAR_API_DOCS"
   schemas:
     ViewerContext:
       type: object


### PR DESCRIPTION
ensures a proper authentication default is added for `x-api-key`

docs: https://docs.readme.com/main/docs/openapi-extensions#authentication-defaults