### PR TITLE
feat: add 'sort_type' param to /cast/conversation

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -55,6 +55,12 @@ components:
         - desc_chron
         - algorithmic
       example: "desc_chron"
+    CastConversationSortType:
+      type: string
+      enum:
+        - desc_chron
+        - algorithmic
+      example: "desc_chron"
     ForYouProvider:
       type: string
       enum:
@@ -4310,6 +4316,12 @@ paths:
           example: 3
           schema:
             $ref: "#/components/schemas/Fid"
+        - name: sort_type
+          in: query
+          required: false
+          description: Sort type for the ordering of descendants. Default is `desc_chron`
+          schema:
+            $ref: "#/components/schemas/CastConversationSortType"
         - name: limit
           in: query
           description: Number of results to retrieve (default 20, max 50)


### PR DESCRIPTION
Adds a `sort_type` query param to the `/v2/farcaster/cast/conversation` endpoint. Supports both `desc_chron` (default) and `algorithmic`. Algorithmic is based on engagement

Related API change: https://github.com/neynarxyz/api/pull/842