### PR TITLE
fix: use new, unique operation name for 'v2/user/by_username'

### DIFF
--- a/src/v1/spec.yaml
+++ b/src/v1/spec.yaml
@@ -831,7 +831,7 @@ paths:
       tags:
         - User
       summary: DEPRECATED - Get User Information by username
-      description: Now deprecated, use [v2/user/by_username](https://docs.neynar.com/reference/user-by-username) instead. Returns metadata about a specific user
+      description: Now deprecated, use [v2/user/by_username](https://docs.neynar.com/reference/user-by-username-v2) instead. Returns metadata about a specific user
       externalDocs:
         url: https://docs.neynar.com/reference/user-by-username-v1
       operationId: user-by-username-v1

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -5567,9 +5567,9 @@ paths:
         - User
       summary: "Fetch a user by username"
       description: "Fetches a single hydrated user object given a username"
-      operationId: user-by-username
+      operationId: user-by-username-v2
       externalDocs:
-        url: https://docs.neynar.com/reference/user-by-username
+        url: https://docs.neynar.com/reference/user-by-username-v2
       parameters:
         - $ref: "#/components/parameters/ApiKey"
         - name: username


### PR DESCRIPTION
For some reason, https://docs.neynar.com/reference/user-by-username is still redirecting to https://docs.neynar.com/reference/user-by-username-v1 even after changing the operation id in https://github.com/neynarxyz/OAS/pull/210. 

This PR introduces https://docs.neynar.com/reference/user-by-username-v2 instead for the `/v2/farcaster/user/by_username` route as a workaround
