### PR TITLE
docs: update ChannelMember object to include hydrated/dehydrated channel/user

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1897,10 +1897,18 @@ components:
       properties:
         channel_id:
           $ref: "#/components/schemas/ChannelId"
+          deprecated: true
+          description: Use `channel.id` instead.
         role:
           $ref: "#/components/schemas/ChannelMemberRole"
         user:
-          $ref: "#/components/schemas/User"
+          oneOf:
+            - $ref: "#/components/schemas/User"
+            - $ref: "#/components/schemas/UserDehydrated"
+        channel:
+          oneOf:
+            - $ref: "#/components/schemas/Channel"
+            - $ref: "#/components/schemas/DehydratedChannel"
     ChannelMemberListResponse:
       type: object
       required:


### PR DESCRIPTION
`ChannelMember`, used in many of the channel APIs is now of a format:

- `role`
- `channel_id` (DEPRECATED)
- `channel` (one of `Channel` or `DehydratedChannel`
- `user` (one of `User` or `UserDehydrated`

