### PR TITLE
open-graph-scraper actually returns string for all embedded URL meta tags [NEYN-3302]

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -184,37 +184,37 @@ components:
         alt:
           type: string
         height:
-          type: integer
+          type: string  # Should be 'integer' but open-graph-scraper lies and returns a string
         url:
           type: string
         width:
-          type: integer
+          type: string  # Should be 'integer' but open-graph-scraper lies and returns a string
       required:
         - url
     TwitterPlayerObject:
       type: object
       properties:
         height:
-          type: integer
+          type: string  # Should be 'integer' but open-graph-scraper lies and returns a string
         stream:
           type: string
         url:
           type: string
         width:
-          type: integer
+          type: string  # Should be 'integer' but open-graph-scraper lies and returns a string
       required:
         - url
     ImageObject:
       type: object
       properties:
         height:
-          type: integer
+          type: string  # Should be 'integer' but open-graph-scraper lies and returns a string
         type:
           type: string
         url:
           type: string
         width:
-          type: integer
+          type: string  # Should be 'integer' but open-graph-scraper lies and returns a string
         alt:
           type: string
       required:
@@ -223,13 +223,13 @@ components:
       type: object
       properties:
         height:
-          type: integer
+          type: string  # Should be 'integer' but open-graph-scraper lies and returns a string
         type:
           type: string
         url:
           type: string
         width:
-          type: integer
+          type: string  # Should be 'integer' but open-graph-scraper lies and returns a string
       required:
         - url
     MusicSongObject:
@@ -238,7 +238,7 @@ components:
         disc:
           type: string
         track:
-          type: integer
+          type: string  # Should be 'integer' but open-graph-scraper lies and returns a string
         url:
           type: string
       required:


### PR DESCRIPTION
Another bug reported by Coinbase