### PR TITLE
fix: add 200 response to '/v2/farcaster/user/by_username'

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -5625,6 +5625,12 @@ paths:
           schema:
             $ref: "#/components/schemas/Fid"
       responses:
+        "200":
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"
         "400":
           $ref: "#/components/responses/400Response"
         "404":


### PR DESCRIPTION
Adds the missing 200 response docs to `/v2/farcaster/user/by_username` endpoint