### PR TITLE
docs: remove 'ChannelMember.channel_id' in favor of 'ChannelMember.channel.id'

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1902,7 +1902,6 @@ components:
       type: object
       required:
         - object
-        - channel_id
         - role
         - user
         - channel
@@ -1911,10 +1910,6 @@ components:
           type: string
           enum:
             - member
-        channel_id:
-          $ref: "#/components/schemas/ChannelId"
-          deprecated: true
-          description: Use `channel.id` instead.
         role:
           $ref: "#/components/schemas/ChannelMemberRole"
         user:


### PR DESCRIPTION
This PR removes 'ChannelMember.channel_id' in favor of 'ChannelMember.channel.id'