### PR TITLE
Fix `/cast/conversion` response in readme

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@
 - [ ] I have validated that all new/updated endpoints conform to OAS standards.
 - [ ] I have updated or added necessary schema definitions.
 - [ ] I have ensured that the new schema I have added doesn't exist.
-- [ ] I have added description where ever necessary.
+- [ ] I have added description wherever necessary.
 - [ ] I have ensured that endpoint's responses are correct.
 - [ ] I have considered backward compatibility with previous versions of the API.
 - [ ] I have communicated any breaking changes to the appropriate stakeholders.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1590,7 +1590,20 @@ components:
             direct_replies:
               type: array
               items:
-                $ref: "#/components/schemas/CastWithInteractionsAndConversations"
+                $ref: "#/components/schemas/CastWithInteractionsAndConversationsRef"
+              description: "note: This is recursive. It contains the direct replies to the cast and their direct replies up to n reply_depth."
+    CastWithInteractionsAndConversationsRef:
+      type: object
+      required:
+        - direct_replies
+      allOf:
+        - $ref: "#/components/schemas/CastWithInteractions"
+        - type: object
+          properties:
+            direct_replies:
+              type: array
+              items:
+                type: object
               description: "note: This is recursive. It contains the direct replies to the cast and their direct replies up to n reply_depth."
     Conversation:
       type: object

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1593,6 +1593,7 @@ components:
                 $ref: "#/components/schemas/CastWithInteractionsAndConversationsRef"
               description: "note: This is recursive. It contains the direct replies to the cast and their direct replies up to n reply_depth."
     CastWithInteractionsAndConversationsRef:
+      description: Reference to CastWithInteractionsAndConversations to avoid circular reference
       type: object
       required:
         - direct_replies


### PR DESCRIPTION
## Description of the Change
<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->
Fix the issue of 200 response not rendering for `/cast/converstion`

## OAS Change Summary
<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->
Add a schema to create a copy of the original schema that refers to itself, but replace the self-reference with an empty object. In the original schema, replace the self-reference with a reference to this additional schema to resolve the recursive object issue.

### New/Updated Schemas
<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->
- `CastWithInteractionsAndConversationsRef` - Schema that points to CastWithInteractionsAndConversations
- `CastWithInteractionsAndConversations` - Modified to refer CastWithInteractionsAndConversationsRef rather that itself

## Checklist
<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [x] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor.swagger.io/)
