### PR TITLE
docs: user viewer context now includes mutes and blocks

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1505,12 +1505,24 @@ components:
       required:
         - following
         - followed_by
+        - blocking
+        - blocked_by
+        - muted
       properties:
         following:
           description: Indicates if the viewer is following the user.
           type: boolean
         followed_by:
           description: Indicates if the viewer is followed by the user.
+          type: boolean
+        blocking:
+          description: Indicates if the viewer is blocking the user.
+          type: boolean
+        blocked_by:
+          description: Indicates if the viewer is blocked by the user.
+          type: boolean
+        muted:
+          description: Indicates if the viewer is muted by the user. Note this is a Neynar specific mute, which is not synced with other client-specific mutes.
           type: boolean
     CastWithInteractionsReactions:
       type: object


### PR DESCRIPTION
## Description of the Change
<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

Adds `blocking`, `blocked_by`, and `muted` to the viewer context object.

## OAS Change Summary
<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->

### New/Updated Schemas
<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->
- `UserViewerContext` - has new keys added: `blocking`, `blocked_by`, and `muted`

## Checklist
<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor.swagger.io/)

