### PR TITLE
docs: add '?fold' flag to '/conversation'

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -4512,6 +4512,15 @@ paths:
           description: Sort type for the ordering of descendants. Default is `desc_chron`
           schema:
             $ref: "#/components/schemas/CastConversationSortType"
+        - name: fold
+          in: query
+          required: false
+          description: Show conversation above or below the fold. Lower quality responses are hidden below the fold. Not passing in a value shows the full conversation without any folding.
+          schema:
+            type: string
+            enum:
+              - above
+              - below
         - name: limit
           in: query
           description: Number of results to retrieve (default 20, max 50)


### PR DESCRIPTION
## Description of the Change
<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

This reverts commit b713a63c33edd995d0b767eb963b2008a5dadceb.
This introduces the OAS documentation for `/v2/farcaster/conversation` endpoint with `?fold=` flag

## OAS Change Summary
<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->

Adds optional `?fold=` flag to `/v2/farcaster/conversation`

### New Endpoints
<!-- List any new endpoints added, along with their method, path, and a brief description. -->

n/a

### Updated Endpoints
<!-- List any modified endpoints, describing the change and why it was made. -->
- `GET /v2/farcaster/conversation` - Added query param `fold` which can be either `above` or `below`

### Deprecated Endpoints
<!-- List any endpoints that are now deprecated. -->
n/a

### New/Updated Schemas
<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->
n/a

## Checklist
<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [x] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor.swagger.io/)

## Additional Comments
<!-- Add any additional information that reviewers should be aware of. -->
