### PR TITLE
add more aptly named types for Mutes and Blocks

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -2792,6 +2792,23 @@ components:
         signer:
           $ref: "#/components/schemas/Signer"
     MuteList:
+      deprecated: true
+      type: object
+      required:
+        - object
+        - muted
+        - timestamp
+        - muted_at
+      properties:
+        object:
+          type: string
+          enum:
+            - mute
+        muted:
+          $ref: "#/components/schemas/User"
+        muted_at:
+          $ref: "#/components/schemas/Timestamp"
+    MuteRecord:
       type: object
       required:
         - object
@@ -2816,7 +2833,7 @@ components:
         mutes:
           type: array
           items:
-            $ref: "#/components/schemas/MuteList"
+            $ref: "#/components/schemas/MuteRecord"
         next:
           $ref: "#/components/schemas/NextCursor"
     MuteResponse:
@@ -2830,6 +2847,24 @@ components:
         message:
           type: string
     BlockList:
+      deprecated: true
+      type: object
+      required:
+        - object
+        - timestamp
+        - blocked_at
+      properties:
+        object:
+          type: string
+          enum:
+            - block
+        blocked:
+          $ref: "#/components/schemas/User"
+        blocker:
+          $ref: "#/components/schemas/User"
+        blocked_at:
+          $ref: "#/components/schemas/Timestamp"
+    BlockRecord:
       type: object
       required:
         - object
@@ -2855,10 +2890,10 @@ components:
         blocks:
           type: array
           items:
-            $ref: "#/components/schemas/BlockList"
+            $ref: "#/components/schemas/BlockRecord"
         next:
           $ref: "#/components/schemas/NextCursor"
-    BanList:
+    BanRecord:
       type: object
       required:
         - object
@@ -2882,7 +2917,7 @@ components:
         bans:
           type: array
           items:
-            $ref: "#/components/schemas/BanList"
+            $ref: "#/components/schemas/BanRecord"
         next:
           $ref: "#/components/schemas/NextCursor"
     BanResponse:


### PR DESCRIPTION
## Description of the Change
<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

Adds `BlockRecord` and `MuteRecord`, which are copies of `BlockList` and `MuteList`. The latter are marked deprecated. Change `BanList` to `BanRecord`. We're changing `List` to `Record` because these items are not arrays, they are the items in the arrays so the new name is more intuitive.

## OAS Change Summary
<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->

### New/Updated Schemas
<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->
- `BlockRecord`
- `MuteRecord`

## Checklist
<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor.swagger.io/)

