### PR TITLE
docs: update /v2/farcaster/cast/conversation's default sort type enum to 'chron'

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -58,9 +58,10 @@ components:
     CastConversationSortType:
       type: string
       enum:
+        - chron
         - desc_chron
         - algorithmic
-      example: "desc_chron"
+      example: "chron"
     ForYouProvider:
       type: string
       enum:
@@ -4552,7 +4553,7 @@ paths:
         - name: sort_type
           in: query
           required: false
-          description: Sort type for the ordering of descendants. Default is `desc_chron`
+          description: Sort type for the ordering of descendants. Default is `chron`
           schema:
             $ref: "#/components/schemas/CastConversationSortType"
         - name: fold


### PR DESCRIPTION
## Description of the Change
<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

corrects /v2/farcaster/cast/conversation's default sort type enum as 'chron'

## OAS Change Summary
<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->


### Updated Endpoints
<!-- List any modified endpoints, describing the change and why it was made. -->
- `GET /v2/farcaster/cast/conversation`
    - added sort_type 'chron'
    - updated default sort_type to 'chron' -- this is just a naming fix, it doesn't change the behavior

<img width="655" alt="Screenshot 2024-10-16 at 11 41 31 AM" src="https://github.com/user-attachments/assets/a71554c0-0f66-4c9e-8679-c3cc6fb1c13e">


## Checklist
<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor.swagger.io/)

## Additional Comments
<!-- Add any additional information that reviewers should be aware of. -->
