### PR TITLE
add channel user context for viewer context and author context

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1613,6 +1613,8 @@ components:
               nullable: true
             viewer_context:
               $ref: "#/components/schemas/CastViewerContext"
+            author_channel_context:
+              $ref: "#/components/schemas/ChannelUserContext"
     CastWithInteractionsAndConversations:
       allOf:
         - $ref: "#/components/schemas/CastWithInteractions"
@@ -1860,6 +1862,8 @@ components:
             - channel_dehydrated
         image_url:
           type: string
+        viewer_context:
+          $ref: "#/components/schemas/ChannelUserContext"
     Channel:
       type: object
       required:
@@ -1920,8 +1924,9 @@ components:
           items:
             $ref: "#/components/schemas/User"
         viewer_context:
-          $ref: "#/components/schemas/ChannelViewerContext"
+          $ref: "#/components/schemas/ChannelUserContext"
     ChannelViewerContext:
+      deprecated: true
       type: object
       required:
         - following
@@ -1929,6 +1934,17 @@ components:
         following:
           type: boolean
           description: Indicates if the viewer is following the channel.
+    ChannelUserContext:
+      description: Adds context on the viewer's or author's role in the channel.
+      type: object
+      required:
+        - following
+      properties:
+        following:
+          description: Indicates if the user is following the channel.
+          type: boolean
+        role:
+          $ref: "#/components/schemas/ChannelMemberRole"
     ChannelListResponse:
       type: object
       required:


### PR DESCRIPTION
## Description of the Change
<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

Add the `ChannelUserContext` object and deprecate `ChannelViewerContext`. `ChannelUserContext` replaces `ChannelViewerContext` in the hydrated channel. It's also added to the dehydrated channel and the `CastWithInteractions` as `author_channel_context`.

## OAS Change Summary
<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->

### New/Updated Schemas
<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->
- `ChannelViewerContext`

## Checklist
<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor.swagger.io/)

