### PR TITLE
doc: add latitude and longitude inputs for PATCH /user

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1742,6 +1742,22 @@ components:
           type: string
         display_name:
           type: string
+        location:
+          type: object
+          required:
+            - latitude
+            - longitude
+          properties:
+            latitude:
+              type: number
+              format: double
+              minimum: -90
+              maximum: 90
+            longitude:
+              type: number
+              format: double
+              minimum: -180
+              maximum: 180
     CastViewerContext:
       type: object
       description: Adds context on interactions the viewer has made with the cast.
@@ -4506,6 +4522,8 @@ paths:
               pfp_url: "https://i.imgur.com/keIWEYM.jpg"
               username: "dan"
               display_name: "Dan Romero"
+              latitude: 37.7749
+              longitude: -122.4194
       responses:
         "200":
           description: Successful operation.


### PR DESCRIPTION
## Description of the Change
<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

Adds latitude and longitude as inputs to `PATCH /user`

## OAS Change Summary
<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->

### Updated Endpoints
<!-- List any modified endpoints, describing the change and why it was made. -->
- `PATCH /user` - Now accepts `latitude` and `longitude`.

### New/Updated Schemas
<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->
- `UpdateUserReqBody` - Modified to include additional fields: `latitude` and `longitude`

## Checklist
<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor.swagger.io/)

