### PR TITLE
Embedded cast tweaks [NEYN-3541; NEYN-3525]

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -820,14 +820,26 @@ components:
     EmbedCast:
       type: object
       required:
-        - cast_id
+        - cast
       properties:
         cast_id:
           $ref: "#/components/schemas/CastId"
-        metadata:
-          $ref: "#/components/schemas/EmbedCastMetadata"
-    EmbedCastMetadata:
-      $ref: "#/components/schemas/CastWithoutEmbeds"
+          deprecated: true
+          description: '[DEPRECATED: Use "cast" key instead]'
+        cast:
+          $ref: "#/components/schemas/CastEmbedded"
+    EmbedCastDeep:
+      type: object
+      required:
+        - cast
+      properties:
+        cast_id:
+          cast_id:
+          $ref: "#/components/schemas/CastId"
+          deprecated: true
+          description: '[DEPRECATED: Use "cast" key instead]'
+        cast:
+          $ref: "#/components/schemas/CastDehydrated"
     Frame:
       type: object
       required:
@@ -1350,11 +1362,9 @@ components:
           type: boolean
         viewer_context:
           $ref: "#/components/schemas/UserViewerContext"
-    Embed:
-      oneOf:
-        - $ref: "#/components/schemas/EmbedUrl"
-        - $ref: "#/components/schemas/EmbedCast"
-    CastWithoutEmbeds:
+    CastEmbedded:
+      # This should just be Cast, but have to duplicate to avoid the circular reference caused by embedded casts, 
+      # because Readme chokes on them.
       type: object
       required:
         - hash
@@ -1389,14 +1399,7 @@ components:
                 - $ref: "#/components/schemas/Fid"
               nullable: true
         author:
-          oneOf:
-            - $ref: "#/components/schemas/User"
-            - $ref: "#/components/schemas/UserDehydrated"
-          discriminator:
-            propertyName: object
-            mapping:
-              user: "#/components/schemas/User"
-              user_dehydrated: "#/components/schemas/UserDehydrated"
+          $ref: "#/components/schemas/UserDehydrated"
         text:
           type: string
         timestamp:
@@ -1404,11 +1407,12 @@ components:
         type:
           $ref: "#/components/schemas/CastNotificationType"
         embeds:
-          description: |
-            It is an array of Embed object (Check #/components/schemas/Cast). Embed object is intentionally omitted to break the circular reference.
           type: array
           items:
             type: object
+            oneOf:
+            - $ref: "#/components/schemas/EmbedUrl"
+            - $ref: "#/components/schemas/EmbedCastDeep"
     Cast:
       type: object
       required:
@@ -1443,14 +1447,7 @@ components:
                 - $ref: "#/components/schemas/Fid"
               nullable: true
         author:
-          oneOf:
-            - $ref: "#/components/schemas/User"
-            - $ref: "#/components/schemas/UserDehydrated"
-          discriminator:
-            propertyName: object
-            mapping:
-              user: "#/components/schemas/User"
-              user_dehydrated: "#/components/schemas/UserDehydrated"
+          $ref: "#/components/schemas/User"
         text:
           type: string
         timestamp:
@@ -1458,7 +1455,10 @@ components:
         embeds:
           type: array
           items:
-            $ref: "#/components/schemas/Embed"
+            type: object
+            oneOf:
+            - $ref: "#/components/schemas/EmbedUrl"
+            - $ref: "#/components/schemas/EmbedCast"
         type:
           $ref: "#/components/schemas/CastNotificationType"
     ProfileUrl:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1377,6 +1377,7 @@ components:
         - timestamp
         - type
         - embeds
+        - channel
       properties:
         hash:
           type: string
@@ -1413,6 +1414,10 @@ components:
             oneOf:
             - $ref: "#/components/schemas/EmbedUrl"
             - $ref: "#/components/schemas/EmbedCastDeep"
+        channel:
+          anyOf:
+            - $ref: "#/components/schemas/DehydratedChannel"
+          nullable: true
     Cast:
       type: object
       required:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1421,7 +1421,7 @@ components:
             type: object
             $ref: "#/components/schemas/EmbedDeep"
         channel:
-          anyOf:
+          allOf: # Need this seemingly pointless allOf for the nullable to work
             - $ref: "#/components/schemas/DehydratedChannel"
           nullable: true
     Cast:
@@ -1867,7 +1867,7 @@ components:
               items:
                 $ref: "#/components/schemas/User"
             channel:
-              anyOf:
+              allOf: # Need this seemingly pointless allOf for the nullable to work
                 - $ref: "#/components/schemas/ChannelOrDehydratedChannel"
               nullable: true
             viewer_context:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -2525,15 +2525,18 @@ components:
     CastDehydrated:
       type: object
       required:
-        - hash
         - object
+        - hash
+        - author
       properties:
-        hash:
-          type: string
         object:
           type: string
           enum:
             - cast_dehydrated
+        hash:
+          type: string
+        author:
+          $ref: "#/components/schemas/UserDehydrated"
     ReactionWithUserInfo:
       type: object
       required:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1362,6 +1362,14 @@ components:
           type: boolean
         viewer_context:
           $ref: "#/components/schemas/UserViewerContext"
+    Embed:
+      oneOf:
+        - $ref: "#/components/schemas/EmbedUrl"
+        - $ref: "#/components/schemas/EmbedCast"
+    EmbedDeep:
+      oneOf:
+        - $ref: "#/components/schemas/EmbedUrl"
+        - $ref: "#/components/schemas/EmbedCastDeep"
     CastEmbedded:
       # This should just be Cast, but have to duplicate to avoid the circular reference caused by embedded casts, 
       # because Readme chokes on them.
@@ -1411,9 +1419,7 @@ components:
           type: array
           items:
             type: object
-            oneOf:
-            - $ref: "#/components/schemas/EmbedUrl"
-            - $ref: "#/components/schemas/EmbedCastDeep"
+            $ref: "#/components/schemas/EmbedDeep"
         channel:
           anyOf:
             - $ref: "#/components/schemas/DehydratedChannel"
@@ -1461,9 +1467,7 @@ components:
           type: array
           items:
             type: object
-            oneOf:
-            - $ref: "#/components/schemas/EmbedUrl"
-            - $ref: "#/components/schemas/EmbedCast"
+            $ref: "#/components/schemas/Embed"
         type:
           $ref: "#/components/schemas/CastNotificationType"
     ProfileUrl:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -2527,7 +2527,6 @@ components:
       required:
         - object
         - hash
-        - author
       properties:
         object:
           type: string


### PR DESCRIPTION
## Description of the Change

- Fix embedded cast type (`CastEmbedded`), changing `metadata` to `cast` at Coinbase's request (BREAKING CHANGE) [NEYN-3521]
    - This requires more duplicated code than expected to ensure there are no circular refs since those break Readme
    - [x] Changes made in `api` PR?
- Add `channel` field to CastEmbedded [NEYN-3525]
    - [x] Changes made in `api` PR? 
- Add `author` (`UserDehydrated`) field to `CastDehydrated`
    - Needed for `CastDehydrated` to fully replace deprecated `CastId` object for embedded casts
    - [x] Changes made in `api` PR?


## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [x] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor.swagger.io/)
