### PR TITLE
feat: add endpoints for blocking and unblocking

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1637,6 +1637,16 @@ components:
           $ref: "#/components/schemas/Fid"
         muted_fid:
           $ref: "#/components/schemas/Fid"
+    BlockReqBody:
+      type: object
+      required:
+        - signer_uuid
+        - blocked_fid
+      properties:
+        signer_uuid:
+          $ref: "#/components/schemas/SignerUUID"
+        blocked_fid:
+          $ref: "#/components/schemas/Fid"
     BanReqBody:
       type: object
       required:
@@ -7681,7 +7691,57 @@ paths:
           $ref: "#/components/responses/404Response"
         "500":
           $ref: "#/components/responses/500Response"
-
+  /farcaster/block:
+    post:
+      tags:
+        - Block
+      summary: Block FID
+      description: Adds a block for a given FID.
+      operationId: add-block
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlockReqBody"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperationResponse"
+        "400":
+          $ref: "#/components/responses/400Response"
+        "404":
+          $ref: "#/components/responses/404Response"
+        "500":
+          $ref: "#/components/responses/500Response"
+    delete:
+      tags:
+        - Block
+      summary: Unblock FID
+      description: Deletes a block for a given FID.
+      operationId: delete-block
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlockReqBody"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperationResponse"
+        "400":
+          $ref: "#/components/responses/400Response"
+        "404":
+          $ref: "#/components/responses/404Response"
+        "500":
+          $ref: "#/components/responses/500Response"
   /farcaster/ban/list:
     get:
       tags:


### PR DESCRIPTION
## Description of the Change
<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

Adds `POST /block` and `DELETE /block` routes to block and unblock accounts.

## OAS Change Summary

<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->

### New Endpoints

<!-- List any new endpoints added, along with their method, path, and a brief description. -->

- `POST /v2/farcaster/block` - Block the specified fid for the user associated with the signer
- `DELETE /v2/farcaster/block` - Unblock the user

### New/Updated Schemas

<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->

- `BlockReqBody` - Input for both new endpoints, takes a signer_uuid and a blocked_fid.

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [x] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor.swagger.io/)

