### PR TITLE
feat: endpoint to get metrics of casts matching a query

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Farcaster API V2
-  version: "2.6.1"
+  version: "2.7.0"
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol.
     See the [Neynar docs](https://docs.neynar.com/reference) for more details.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -2614,6 +2614,31 @@ components:
                 $ref: "#/components/schemas/CastWithInteractions"
             next:
               $ref: "#/components/schemas/NextCursor"
+    CastsMetrics:
+      type: object
+      required:
+        - start
+        - resolution_in_seconds
+        - cast_count
+      properties:
+        start:
+          type: string
+          format: date-time
+        resolution_in_seconds:
+          type: integer
+          format: int32
+        cast_count:
+          type: integer
+          format: int32
+    CastsMetricsResponse:
+      type: object
+      required:
+        - metrics
+      properties:
+        metrics:
+          type: array
+          items:
+            $ref: "#/components/schemas/CastsMetrics"
     FeedResponse:
       type: object
       required:
@@ -5324,6 +5349,56 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CastsSearchResponse"
+        "400":
+          $ref: "#/components/responses/400Response"
+  /farcaster/cast/metrics:
+    get:
+      tags:
+        - Cast
+      summary: Metrics for casts
+      description: Fetches metrics casts matching a query
+      externalDocs:
+        url: https://docs.neynar.com/reference/fetch-cast-metrics
+      operationId: fetch-cast-metrics
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: "Query string to search for casts"
+          example: "star wars"
+          schema:
+            type: string
+        - name: interval
+          in: query
+          required: false
+          description: "Interval of time for which to fetch metrics. Choices are `1d`, `7d`, `30d`"
+          schema:
+            type: string
+            enum:
+              - 1d
+              - 7d
+              - 30d
+          default: "30d"
+        - name: author_fid
+          in: query
+          required: false
+          description: "Fid of the user whose casts you want to search"
+          example: 194
+          schema:
+            $ref: "#/components/schemas/Fid"
+        - name: channel_id
+          in: query
+          required: false
+          schema:
+            type: string
+          description: "Channel ID of the casts you want to search"
+      responses:
+        "200":
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CastMetricsResponse"
         "400":
           $ref: "#/components/responses/400Response"
   /farcaster/cast/conversation:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -4492,6 +4492,8 @@ tags:
     description: Operations related to onchain data
   - name: Login
     description: Operations related to login
+  - name: Metrics
+    description: Operations related to retrieving metrics
 
 paths:
   /farcaster/user/fid:
@@ -5354,7 +5356,7 @@ paths:
   /farcaster/cast/metrics:
     get:
       tags:
-        - Cast
+        - Metrics
       summary: Metrics for casts
       description: Fetches metrics casts matching a query
       externalDocs:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -5378,7 +5378,6 @@ paths:
               - 1d
               - 7d
               - 30d
-          default: "30d"
         - name: author_fid
           in: query
           required: false

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -5398,7 +5398,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CastMetricsResponse"
+                $ref: "#/components/schemas/CastsMetricsResponse"
         "400":
           $ref: "#/components/responses/400Response"
   /farcaster/cast/conversation:


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

Documents the new `/v2/farcaster/cast/metrics` endpoint, which returns counts of casts matching a query per unit time.

## OAS Change Summary

<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->

### New Endpoints

<!-- List any new endpoints added, along with their method, path, and a brief description. -->

- `GET /v2/farcaster/cast/metrics` - Get the number of casts matching a query over time.


### New/Updated Schemas

<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->

- `CastsMetrics` - Object defining one datapoint in time
- `CastsMetricsResponse` - Response type of the new endpoint, contains an array of `CastsMetrics`

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

