### PR TITLE
Add frames/catalog endpoint [NEYN-4193]

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -204,6 +204,101 @@ components:
           type: string
         metadata:
           $ref: "#/components/schemas/EmbedUrlMetadata"
+
+    FarcasterManifest:
+      type: object
+      properties:
+        account_association:
+          type: object
+          properties:
+            header:
+              type: string
+            payload:
+              type: string
+            signature:
+              type: string
+          required:
+            - header
+            - payload
+            - signature
+        frame:
+          type: object
+          properties:
+            version:
+              type: string
+              enum: ["1"]
+            name:
+              type: string
+              maxLength: 32
+            home_url:
+              type: string
+              maxLength: 512
+            icon_url:
+              type: string
+              maxLength: 512
+            image_url:
+              type: string
+              maxLength: 512
+            button_title:
+              type: string
+              maxLength: 32
+            splash_image_url:
+              type: string
+              maxLength: 512
+            splash_background_color:
+              type: string
+            webhook_url:
+              type: string
+              maxLength: 512
+          required:
+            - version
+            - name
+            - home_url
+            - icon_url
+            - image_url
+            - button_title
+        triggers:
+          type: array
+          items:
+            oneOf:
+              - type: object
+                properties:
+                  type:
+                    type: string
+                    enum: ["cast"]
+                  id:
+                    type: string
+                  url:
+                    type: string
+                    maxLength: 512
+                  name:
+                    type: string
+                    maxLength: 32
+                required:
+                  - type
+                  - id
+                  - url
+              - type: object
+                properties:
+                  type:
+                    type: string
+                    enum: ["composer"]
+                  id:
+                    type: string
+                  url:
+                    type: string
+                    maxLength: 512
+                  name:
+                    type: string
+                    maxLength: 32
+                required:
+                  - type
+                  - id
+                  - url
+      required:
+        - account_association
+        - frame
+
     # TwitterImageObject:
     #   type: object
     #   properties:
@@ -927,34 +1022,10 @@ components:
             - name
             - icon
           properties:
-            name:
-              type: string
-              description: App name for Frame v2
-              examples:
-                - Yionk!
-                - CastStorage
-            title:
-              type: string
-              description: Action button text
-              examples:
-                - Yionk flag
-                - Buy storage
-            # properties below come from Farcaster Manifest
-            # homeUrl is under frames_url
-            # see: https://docs.farcaster.xyz/developers/frames/v2/spec#frame-manifest
-            icon:
-              type: string
-              description: Icon URL of frame app
+            manifest:
+              $ref: "#/components/schemas/FarcasterManifest"
             author:
               $ref: "#/components/schemas/User"
-            # splash_* properties are required in v2 FrameEmbed but not honored by Warpcast
-            # we make them optional too
-            splash_image:
-              type: string
-              description: Splash screen image URL
-            splash_background_color:
-              type: string
-              description: Splash screen background color
 
     SubscriptionTier:
       type: object

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -3395,40 +3395,7 @@ components:
         frames:
           type: array
           items:
-            type: object
-            required:
-              - name
-              - home_url
-              - icon_url
-              - image_url
-              - button_title
-              - splash_image_url
-              - splash_background_color
-              - author
-            properties:
-              name:
-                type: string
-                description: Name of the frame
-              home_url:
-                type: string
-                description: Home URL of the frame
-              icon_url:
-                type: string
-                description: URL of the frame's icon
-              image_url:
-                type: string
-                description: URL of the frame's image
-              button_title:
-                type: string
-                description: Title of the frame's button
-              splash_image_url:
-                type: string
-                description: URL of the frame's splash image
-              splash_background_color:
-                type: string
-                description: Background color for the frame's splash screen
-              author:
-                $ref: "#/components/schemas/User"
+            $ref: "#/components/schemas/FrameV2"
         next:
           $ref: "#/components/schemas/NextCursor"
     SendFrameNotificationsResponse:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -925,8 +925,6 @@ components:
           required:
             - title
             - name
-            - splash_image
-            - splash_background_color
           properties:
             name:
               type: string
@@ -948,6 +946,8 @@ components:
             icon:
               type: string
               description: Icon URL of frame app
+            # splash_* properties are required in v2 FrameEmbed but not honored by Warpcast
+            # we make them optional too
             splash_image:
               type: string
               description: Splash screen image URL

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -3323,6 +3323,51 @@ components:
           $ref: "#/components/schemas/FrameTransaction"
         address:
           $ref: "#/components/schemas/FrameAddress"
+    FrameCatalogResponse:
+      type: object
+      required:
+        - frames
+        - next
+      properties:
+        frames:
+          type: array
+          items:
+            type: object
+            required:
+              - name
+              - home_url
+              - icon_url
+              - image_url
+              - button_title
+              - splash_image_url
+              - splash_background_color
+              - author
+            properties:
+              name:
+                type: string
+                description: Name of the frame
+              home_url:
+                type: string
+                description: Home URL of the frame
+              icon_url:
+                type: string
+                description: URL of the frame's icon
+              image_url:
+                type: string
+                description: URL of the frame's image
+              button_title:
+                type: string
+                description: Title of the frame's button
+              splash_image_url:
+                type: string
+                description: URL of the frame's splash image
+              splash_background_color:
+                type: string
+                description: Background color for the frame's splash screen
+              author:
+                $ref: "#/components/schemas/User"
+        next:
+          $ref: "#/components/schemas/NextCursor"
     SendFrameNotificationsResponse:
       type: object
       required:
@@ -6397,6 +6442,38 @@ paths:
                 $ref: "#/components/schemas/DeleteFrameResponse"
         "404":
           $ref: "#/components/responses/404Response"
+
+  /farcaster/frame/catalog:
+    get:
+      tags:
+        - Frame
+      summary: Frames Catalog
+      description: A curated list of featured frames
+      operationId: fetch-frame-catalog
+      parameters:
+        - name: limit
+          in: query
+          description: Number of results to fetch
+          required: false
+          schema:
+            type: integer
+            default: 100
+            maximum: 100
+          x-is-limit-param: true
+        - name: cursor
+          in: query
+          description: Pagination cursor
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FrameCatalogResponse"
+
   /farcaster/frame/list:
     get:
       tags:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -925,13 +925,11 @@ components:
           required:
             - title
             - name
+            - icon
           properties:
             name:
               type: string
               description: App name for Frame v2
-            home:
-              type: string
-              description: Home URL of the frame app
               examples:
                 - Yionk!
                 - CastStorage
@@ -942,10 +940,13 @@ components:
                 - Yionk flag
                 - Buy storage
             # properties below come from Farcaster Manifest
+            # homeUrl is under frames_url
             # see: https://docs.farcaster.xyz/developers/frames/v2/spec#frame-manifest
             icon:
               type: string
               description: Icon URL of frame app
+            author:
+              $ref: "#/components/schemas/User"
             # splash_* properties are required in v2 FrameEmbed but not honored by Warpcast
             # we make them optional too
             splash_image:
@@ -954,8 +955,6 @@ components:
             splash_background_color:
               type: string
               description: Splash screen background color
-            author:
-              $ref: "#/components/schemas/User"
 
     SubscriptionTier:
       type: object

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -856,6 +856,21 @@ components:
         cast:
           $ref: "#/components/schemas/CastDehydrated"
     Frame:
+      discriminator:
+        propertyName: "version"
+      oneOf:
+        - $ref: "#/components/schemas/FrameV1"
+        - $ref: "#/components/schemas/FrameV2"
+      mapping:
+        # 'vNext' for v1, and 'next' for v2.
+        # Bit confusing but that's the spec:
+        # v1: https://docs.farcaster.xyz/developers/frames/spec#constructing-a-frame
+        # v2: https://docs.farcaster.xyz/developers/frames/v2/spec#frame-embed-metatags
+        vNext: "#/components/schemas/FrameV1"
+        next: "#/components/schemas/FrameV2"
+
+    FrameBase:
+      description: Frame base object used across all versions
       type: object
       required:
         - version
@@ -864,36 +879,84 @@ components:
       properties:
         version:
           type: string
-          description: Version of the frame
+          description: Version of the frame, 'next' for v2, 'vNext' for v1
         image:
           type: string
           description: URL of the image
-        buttons:
-          type: array
-          items:
-            $ref: "#/components/schemas/FrameActionButton"
-        post_url:
-          type: string
-          description: Post URL to take an action on this frame
         frames_url:
           type: string
-          description: URL of the frames
-        title:
-          type: string
-        image_aspect_ratio:
-          type: string
-        input:
-          type: object
+          description: Launch URL of the frame
+
+    FrameV1:
+      description: Frame v1 object
+      allOf:
+        - $ref: "#/components/schemas/FrameBase"
+        - type: object
           properties:
-            text:
+            buttons:
+              type: array
+              items:
+                $ref: "#/components/schemas/FrameActionButton"
+            post_url:
               type: string
-              description: Input text for the frame
-        state:
-          type: object
+              description: Post URL to take an action on this frame
+            title:
+              type: string
+            image_aspect_ratio:
+              type: string
+            input:
+              type: object
+              properties:
+                text:
+                  type: string
+                  description: Input text for the frame
+            state:
+              type: object
+              properties:
+                serialized:
+                  type: string
+                  description: State for the frame in a serialized format
+    FrameV2:
+      description: Frame v2 object
+
+      allOf:
+        - $ref: "#/components/schemas/FrameBase"
+        # these required properties come from FrameEmbed
+        # See: https://docs.farcaster.xyz/developers/frames/v2/spec#frame-embed-metatags
+        - type: object
+          required:
+            - title
+            - name
+            - splash_image
+            - splash_background_color
           properties:
-            serialized:
+            name:
               type: string
-              description: State for the frame in a serialized format
+              description: App name for Frame v2
+            home:
+              type: string
+              description: Home URL of the frame app
+              examples:
+                - Yionk!
+                - CastStorage
+            title:
+              type: string
+              description: Action button text
+              examples:
+                - Yionk flag
+                - Buy storage
+            icon:
+              type: string
+              description: Icon URL of frame app
+            splash_image:
+              type: string
+              description: Splash screen image URL
+            splash_background_color:
+              type: string
+              description: Splash screen background color
+            author:
+              $ref: "#/components/schemas/User"
+
     SubscriptionTier:
       type: object
       properties:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -862,8 +862,7 @@ components:
         - $ref: "#/components/schemas/FrameV1"
         - $ref: "#/components/schemas/FrameV2"
       mapping:
-        # 'vNext' for v1, and 'next' for v2.
-        # Bit confusing but that's the spec:
+        # 'vNext' for v1, and 'next' for v2. See specs:
         # v1: https://docs.farcaster.xyz/developers/frames/spec#constructing-a-frame
         # v2: https://docs.farcaster.xyz/developers/frames/v2/spec#frame-embed-metatags
         vNext: "#/components/schemas/FrameV1"
@@ -918,10 +917,9 @@ components:
                   description: State for the frame in a serialized format
     FrameV2:
       description: Frame v2 object
-
       allOf:
         - $ref: "#/components/schemas/FrameBase"
-        # these required properties come from FrameEmbed
+        # required properties come from FrameEmbed
         # See: https://docs.farcaster.xyz/developers/frames/v2/spec#frame-embed-metatags
         - type: object
           required:
@@ -945,6 +943,8 @@ components:
               examples:
                 - Yionk flag
                 - Buy storage
+            # properties below come from Farcaster Manifest
+            # see: https://docs.farcaster.xyz/developers/frames/v2/spec#frame-manifest
             icon:
               type: string
               description: Icon URL of frame app


### PR DESCRIPTION
- Frame v1 & Frame v2 objects share 3 properties: version, image, frames_url.
- Added [discriminated union](https://swagger.io/docs/specification/v3_0/data-models/oneof-anyof-allof-not/) for Frame v1 & Frame v2 since both objects have different shape to enable proper typing in SDK and clear distinction in the docs. I verified that Readme.io [supports it](https://docs.readme.com/main/docs/openapi-compatibility-chart#schema-object).

Implementation: https://github.com/neynarxyz/monorepo/pull/1277