### PR TITLE
Add new `app:` UserDehydrated subobject to cast response objects [NEYN-3926]

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1791,6 +1791,10 @@ components:
                 - $ref: "#/components/schemas/Fid"
         author:
           $ref: "#/components/schemas/UserDehydrated"
+        app:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/AppDehydrated"
         text:
           type: string
         timestamp:
@@ -2931,6 +2935,10 @@ components:
           type: string
         author:
           $ref: "#/components/schemas/UserDehydrated"
+        app:
+          oneOf:
+            - type: "null"
+            - $ref: "#/components/schemas/AppDehydrated"
     ReactionWithUserInfo:
       type: object
       required:
@@ -3038,6 +3046,24 @@ components:
           type: string
           enum:
             - user_dehydrated
+        fid:
+          $ref: "#/components/schemas/Fid"
+        username:
+          type: string
+        display_name:
+          type: string
+        pfp_url:
+          type: string
+    AppDehydrated:
+      type: object
+      required:
+        - object
+        - fid
+      properties:
+        object:
+          type: string
+          enum:
+            - app_dehydrated
         fid:
           $ref: "#/components/schemas/Fid"
         username:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Farcaster API V2
-  version: "2.11.0"
+  version: "2.12.0"
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol.
     See the [Neynar docs](https://docs.neynar.com/reference) for more details.
@@ -914,6 +914,9 @@ components:
                       video: "#/components/schemas/OembedVideoData"
                       photo: "#/components/schemas/OembedPhotoData"
                       link: "#/components/schemas/OembedLinkData"
+        frame:
+          $ref: "#/components/schemas/Frame"
+
     ChannelMemberRole:
       type: string
       description: The role of a channel member
@@ -964,6 +967,9 @@ components:
         # v2: https://docs.farcaster.xyz/developers/frames/v2/spec#frame-embed-metatags
         vNext: "#/components/schemas/FrameV1"
         next: "#/components/schemas/FrameV2"
+        "1": "#/components/schemas/FrameV2"
+        "0.0.0": "#/components/schemas/FrameV2"
+        "0.0.1": "#/components/schemas/FrameV2"
 
     FrameBase:
       description: Frame base object used across all versions

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Farcaster API V2
-  version: "2.12.0"
+  version: "2.13.0"
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol.
     See the [Neynar docs](https://docs.neynar.com/reference) for more details.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -7118,7 +7118,7 @@ paths:
       tags:
         - Frame
       summary: |
-        List of frame notification tokens.
+        List of frame notification tokens
       description: |
         Returns a list of notifications tokens related for an app
       externalDocs:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1794,7 +1794,7 @@ components:
         app:
           oneOf:
             - type: "null"
-            - $ref: "#/components/schemas/AppDehydrated"
+            - $ref: "#/components/schemas/UserDehydrated"
         text:
           type: string
         timestamp:
@@ -2938,7 +2938,7 @@ components:
         app:
           oneOf:
             - type: "null"
-            - $ref: "#/components/schemas/AppDehydrated"
+            - $ref: "#/components/schemas/UserDehydrated"
     ReactionWithUserInfo:
       type: object
       required:
@@ -3046,24 +3046,6 @@ components:
           type: string
           enum:
             - user_dehydrated
-        fid:
-          $ref: "#/components/schemas/Fid"
-        username:
-          type: string
-        display_name:
-          type: string
-        pfp_url:
-          type: string
-    AppDehydrated:
-      type: object
-      required:
-        - object
-        - fid
-      properties:
-        object:
-          type: string
-          enum:
-            - app_dehydrated
         fid:
           $ref: "#/components/schemas/Fid"
         username:


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->
Reflect the addition of app info to returned cast objects in https://github.com/neynarxyz/monorepo/pull/1369

## OAS Change Summary

<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->
Adds new field named `app:` to cast response objects of type `UserDehydrated`. Specifies which Farcaster client app, e.g. Warpcast, Supercast, Neynar, the cast was created through.


