### PR TITLE
Mark image_url as optional in FrameEmbed

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Farcaster API V2
-  version: "2.11.0"
+  version: "2.12.1"
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol.
     See the [Neynar docs](https://docs.neynar.com/reference) for more details.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -259,7 +259,6 @@ components:
             - name
             - home_url
             - icon_url
-            - image_url
         triggers:
           type: array
           items:


### PR DESCRIPTION
Missed change from https://github.com/neynarxyz/monorepo/commit/c6b3e839bbd0e2425b55b615273b02907556dc45