### PR TITLE
feat: semantic and hybrid search of casts

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -5496,6 +5496,17 @@ paths:
           example: "star wars"
           schema:
             type: string
+        - name: mode
+          in: query
+          required: false
+          description: "Choices are `literal` (default), `semantic`, `hybrid`"
+          example: "literal"
+          schema:
+            type: string
+            enum:
+              - literal
+              - semantic
+              - hybrid
         - name: author_fid
           in: query
           required: false

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Farcaster API V2
-  version: "2.15.1"
+  version: "2.16"
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol.
     See the [Neynar docs](https://docs.neynar.com/reference) for more details.


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

Adds a query param `mode` to the `/cast/search` endpoint which allows the selection of `literal`, `semantic`, or `hybrid` search.

## OAS Change Summary

<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->

### Updated Endpoints

<!-- List any modified endpoints, describing the change and why it was made. -->

- `GET /cast/search` - Add `mode` param.


## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [x] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

