### PR TITLE
feat: algorithmic cast search

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -86,6 +86,8 @@ components:
         - algorithmic
       examples:
         - "desc_chron"
+    SearchSortType:
+      $ref: "#/components/schemas/FollowSortType"
     CastConversationSortType:
       type: string
       enum:
@@ -1188,7 +1190,7 @@ components:
         - id
         - url
         - type
-        - config 
+        - config
         - status
       properties:
         id:
@@ -1197,7 +1199,7 @@ components:
         url:
           type: string
           format: uri
-          description: URL that can be used to access the transaction frame 
+          description: URL that can be used to access the transaction frame
         type:
           $ref: "#/components/schemas/TransactionFrameType"
         config:
@@ -1227,7 +1229,7 @@ components:
           pay: "#/components/schemas/TransactionFramePay"
       oneOf:
         - $ref: "#/components/schemas/TransactionFramePay"
-    
+
     TransactionFrameStatus:
       type: string
       enum:
@@ -5655,6 +5657,12 @@ paths:
               - literal
               - semantic
               - hybrid
+        - name: sort_type
+          in: query
+          required: false
+          description: Sort type for search. Default is `desc_chron`
+          schema:
+            $ref: "#/components/schemas/SearchSortType"
         - name: author_fid
           in: query
           required: false

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Farcaster API V2
-  version: "2.18.0"
+  version: "2.19.0"
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol.
     See the [Neynar docs](https://docs.neynar.com/reference) for more details.


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

Add the `sort_type` parameter to `/casts/search` which can be `desc_chron` or `algorithmic`

## OAS Change Summary

<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->

### Updated Endpoints

<!-- List any modified endpoints, describing the change and why it was made. -->

- `GET /casts/search` - Adds `sort_type` so devs can specify `desc_chron` (current behavior and default) or `algorithmic`, which is a new option.

### New/Updated Schemas

<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->

- `SearchSortType` - This is an alias of `FollowSortType` but uses a new name to avoid breaking changes.

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [x] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

LMK if there's a better approach to managing the sort type objects. My best guess was that creating an alias for `FollowSortType` was better than changing the name of that type.
