### PR TITLE
Support for primary eth/sol addresses [NEYN-4660]

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Farcaster API V2
-  version: "2.20.0"
+  version: "2.21.0"
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol.
     See the [Neynar docs](https://docs.neynar.com/reference) for more details.
@@ -1793,6 +1793,8 @@ components:
           required:
             - eth_addresses
             - sol_addresses
+            - primary_eth_address
+            - primary_sol_address
           properties:
             eth_addresses:
               type: array
@@ -1804,6 +1806,16 @@ components:
               description: List of verified Solana addresses of the user sorted by oldest to most recent.
               items:
                 $ref: "#/components/schemas/SolAddress"
+            primary_eth_address:
+              description: If set, this is the primary Ethereum address of the user.
+              oneOf:
+                - $ref: "#/components/schemas/Address"
+                - type: "null"
+            primary_sol_address:
+              description: If set, this is the primary Solana address of the user.
+              oneOf:
+                - $ref: "#/components/schemas/SolAddress"
+                - type: "null"
         verified_accounts:
           type: array
           description: Verified accounts of the user on other platforms, currently only X is supported.
@@ -2302,6 +2314,8 @@ components:
           $ref: "#/components/schemas/VerificationType"
         chain_id:
           $ref: "#/components/schemas/VerificationChainId"
+        is_primary:
+          type: boolean
     RemoveVerificationReqBody:
       type: object
       required:


### PR DESCRIPTION
Support `is_primary` field in POST `/user/verification` request object and include new `primary_eth_address` and `primary_sol_address` fields in User response object


