### PR TITLE
feat: post impressions to filter them from feeds

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Farcaster API V2
-  version: "2.22.0"
+  version: "2.23.0"
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol.
     See the [Neynar docs](https://docs.neynar.com/reference) for more details.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -5690,11 +5690,11 @@ paths:
               impressions:
                 [
                   {
-                    hash: "0x1ea99cbed57e4020314ba3fadd7c692d2de34d5f",
+                    cast_hash: "0x1ea99cbed57e4020314ba3fadd7c692d2de34d5f",
                     timestamp: "2024-10-08T22:03:49.000Z",
                   },
                   {
-                    hash: "0x1ea99cbed57e4020314ba3fadd7c692d2de34d5f",
+                    cast_hash: "0x1ea99cbed57e4020314ba3fadd7c692d2de34d5f",
                     timestamp: "2024-10-08T22:03:49.000Z",
                   },
                 ]

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -2172,6 +2172,27 @@ components:
           $ref: "#/components/schemas/Idem"
         parent_author_fid:
           $ref: "#/components/schemas/Fid"
+    PostCastImpressionsReqBody:
+      type: object
+      required:
+        - impressions
+        - viewer_fid
+      properties:
+        impressions:
+          type: array
+          items:
+            type: object
+            required:
+              - cast_hash
+              - timestamp
+            properties:
+              cast_hash:
+                $ref: "#/components/schemas/CastHash"
+              timestamp:
+                $ref: "#/components/schemas/Timestamp"
+              duration:
+                type: integer
+                description: Duration in milliseconds the cast was viewed
     MuteReqBody:
       type: object
       required:
@@ -5649,6 +5670,45 @@ paths:
                 $ref: "#/components/schemas/CastsResponse"
         "400":
           $ref: "#/components/responses/400Response"
+  /farcaster/cast/impressions:
+    post:
+      tags:
+        - Cast
+      summary: Record impressions of casts
+      description: Record impressions of casts so that they can be filtered from feeds
+      externalDocs:
+        url: https://docs.neynar.com/reference/publish-cast-impressions
+      operationId: publish-cast-impressions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PostCastImpressionsReqBody"
+            example:
+              viewer_fid: 3,
+              impressions:
+                [
+                  {
+                    hash: "0x1ea99cbed57e4020314ba3fadd7c692d2de34d5f",
+                    timestamp: "2024-10-08T22:03:49.000Z",
+                  },
+                  {
+                    hash: "0x1ea99cbed57e4020314ba3fadd7c692d2de34d5f",
+                    timestamp: "2024-10-08T22:03:49.000Z",
+                  },
+                ]
+      responses:
+        "200":
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OperationResponse"
+        "400":
+          $ref: "#/components/responses/400Response"
+        "500":
+          $ref: "#/components/responses/500Response"
   /farcaster/cast/search:
     get:
       tags:


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

New route for recording that a user has seen a cast. These casts will soon be filtered from certain feeds.

## OAS Change Summary

<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->

### New Endpoints

<!-- List any new endpoints added, along with their method, path, and a brief description. -->

- `POST /cast/impressions` - Record cast impressions for users.

### New/Updated Schemas

<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->

- `PostCastImpressionsReqBody` - Schema for posting impressions.

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [x] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)
