### PR TITLE
feat: add shared component TrendingTimeWindow

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -55,6 +55,15 @@ components:
         - 2
         - 194
         - 19960
+    TrendingTimeWindow:
+      type: string
+      enum:
+        - 1h
+        - 6h
+        - 12h
+        - 24h
+        - 7d
+      description: Time window for trending content
     ChannelId:
       type: string
       description: The unique identifier of a farcaster channel
@@ -6507,15 +6516,12 @@ paths:
         - name: time_window
           in: query
           description: Time window for trending casts (7d window for channel feeds only)
+          required: false
           schema:
-            type: string
-            enum:
-              - 1h
-              - 6h
-              - 12h
-              - 24h
-              - 7d
-            default: 24h
+            allOf:
+              - $ref: "#/components/schemas/TrendingTimeWindow"
+              - default: 24h
+          example: 24h
         - name: channel_id
           in: query
           description: Channel ID to filter trending casts. Less active channels might have no casts in the time window selected. Provide either `channel_id` or `parent_url`, not both.
@@ -6859,6 +6865,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: time_window
+          in: query
+          description: Time window to fetch frames for
+          required: false
+          schema:
+            $ref: "#/components/schemas/TrendingTimeWindow"
       responses:
         "200":
           description: Successful response
@@ -9584,3 +9596,4 @@ paths:
   #         $ref: "#/components/responses/400Response"
   #       "404":
   #         $ref: "#/components/responses/404Response"
+

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -6867,7 +6867,7 @@ paths:
             type: string
         - name: time_window
           in: query
-          description: Time window to fetch frames for
+          description: Time window used to calculate the change in trending score for each frame, used to sort frame results
           required: false
           schema:
             $ref: "#/components/schemas/TrendingTimeWindow"


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->
This PR adds a shared `TrendingTimeWindow` component to use as query params for the _/farcaster/frame/catalog_ and _/farcaster/feed/trending_ endpoints.

## OAS Change Summary

<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->
New optional query param `time_window` for _/farcaster/frame/catalotg_ endpoint. The other changes are just refactors.

### New Endpoints

<!-- List any new endpoints added, along with their method, path, and a brief description. -->

n/a

### Updated Endpoints

<!-- List any modified endpoints, describing the change and why it was made. -->

- `GET /v2/farcaster/frame/catalog` - new query param `time_window` specifies the time period delta to use when sorting frames by SUM(casts_reaction_score), e.g. `time_window=6h` returns frames sorted by `SUM(casts_reaction_score)` for the past 6 hours minus the same score for the preceding 6 hours.

### Deprecated Endpoints

<!-- List any endpoints that are now deprecated. -->

n/a

### New/Updated Schemas

<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->

- `TrendingTimeWindow` - New enum to specify available time windows for trending stats

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders. **n/a**
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

<!-- Add any additional information that reviewers should be aware of. -->
