### PR TITLE
Added token to docs repo fetch call

### DIFF
--- a/.github/workflows/oas-to-docs-pr.yaml
+++ b/.github/workflows/oas-to-docs-pr.yaml
@@ -23,6 +23,7 @@ jobs:
           repository: "neynarxyz/docs.git"
           ref: "main"
           path: "docs" # Checkout docs repository into a directory named "docs"
+          token: ${{ secrets.OAS_TO_SDK_FGPAT }}
 
       - name: Copy updated YAML files to docs repository
         run: |


### PR DESCRIPTION
## Description of the Change
Minor fix to the OAS-to-docs workflow.  The token got vibe-deleted at some point.  re-added.