### PR TITLE
Added mention values to Channel schema per NEYN-3324

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Farcaster API V2
-  version: "2.29.0"
+  version: "2.30.0"
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol.
     See the [Neynar docs](https://docs.neynar.com/reference) for more details.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -2759,14 +2759,23 @@ components:
           type: string
         url:
           type: string
-        name:
-          type: string
-        description:
-          type: string
         object:
           type: string
           enum:
             - channel
+        name:
+          type: string
+        description:
+          type: string
+        description_mentioned_profiles:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserDehydrated"
+        description_mentioned_profiles_ranges:
+          description: Positions within the text (inclusive start, exclusive end) where each mention occurs.
+          type: array
+          items:
+            $ref: "#/components/schemas/CastTextRange"
         created_at:
           description: Epoch timestamp in seconds.
           type: number
@@ -9676,4 +9685,3 @@ paths:
   #         $ref: "#/components/responses/400Response"
   #       "404":
   #         $ref: "#/components/responses/404Response"
-

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -953,7 +953,7 @@ components:
           $ref: "#/components/schemas/Fid"
         hash:
           type: string
-    CastTextRange:
+    TextRange:
       type: object
       required:
         - start
@@ -1793,7 +1793,7 @@ components:
                     Each index within this list corresponds to the same-numbered index in the mentioned_profiles list.
                   type: array
                   items:
-                    $ref: "#/components/schemas/CastTextRange"
+                    $ref: "#/components/schemas/TextRange"
                 mentioned_channels:
                   type: array
                   items:
@@ -1804,7 +1804,7 @@ components:
                     Each index within this list corresponds to the same-numbered index in the mentioned_channels list.
                   type: array
                   items:
-                    $ref: "#/components/schemas/CastTextRange"
+                    $ref: "#/components/schemas/TextRange"
             location:
               $ref: "#/components/schemas/Location"
         follower_count:
@@ -2524,7 +2524,7 @@ components:
                 Each index within this list corresponds to the same-numbered index in the mentioned_profiles list.
               type: array
               items:
-                $ref: "#/components/schemas/CastTextRange"
+                $ref: "#/components/schemas/TextRange"
             mentioned_channels:
               type: array
               items:
@@ -2535,7 +2535,7 @@ components:
                 Each index within this list corresponds to the same-numbered index in the mentioned_channels list.
               type: array
               items:
-                $ref: "#/components/schemas/CastTextRange"
+                $ref: "#/components/schemas/TextRange"
             channel:
               oneOf:
                 - $ref: "#/components/schemas/ChannelOrChannelDehydrated"
@@ -2775,7 +2775,7 @@ components:
           description: Positions within the text (inclusive start, exclusive end) where each mention occurs.
           type: array
           items:
-            $ref: "#/components/schemas/CastTextRange"
+            $ref: "#/components/schemas/TextRange"
         created_at:
           description: Epoch timestamp in seconds.
           type: number


### PR DESCRIPTION
## Description of the Change

- Included two new properties of the Channel schema
- Renamed `CastTextRange` to just `TextRange` because its used outside the context of Casts
- Bumped spec version to 2.30.0

### New/Updated Schemas

<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->

- `Channel` - Modified to include additional fields.

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [ ] I have validated that all new/updated endpoints conform to OAS standards.
- [ ] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

<!-- Add any additional information that reviewers should be aware of. -->
