### PR TITLE
fix: add externalDocs for relevant frames

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Farcaster API V2
-  version: "2.32.0"
+  version: "2.33.0"
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol.
     See the [Neynar docs](https://docs.neynar.com/reference) for more details.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -6934,7 +6934,7 @@ paths:
       summary: Relevant frames
       description: Fetch a list of frames relevant to the user based on casts by users with strong affinity score for the user
       externalDocs:
-        url: https://docs.neynar.com/reference/fetch-frame-relevant.mdx
+        url: https://docs.neynar.com/reference/fetch-frame-relevant
       operationId: fetch-relevant-frames
       parameters:
         - name: viewer_fid

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -6933,6 +6933,8 @@ paths:
         - Frame
       summary: Relevant frames
       description: Fetch a list of frames relevant to the user based on casts by users with strong affinity score for the user
+      externalDocs:
+        url: https://docs.neynar.com/reference/fetch-frame-relevant.mdx
       operationId: fetch-relevant-frames
       parameters:
         - name: viewer_fid


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

## OAS Change Summary

<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->
This PR adds the externalDocs URL for the relevant frames endpoint, which I forgot in my initial PR #310 

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [ ] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

<!-- Add any additional information that reviewers should be aware of. -->
