### PR TITLE
chore: change reaction type enum names

### DIFF
--- a/src/hub-rest-api/spec.yaml
+++ b/src/hub-rest-api/spec.yaml
@@ -410,7 +410,6 @@ paths:
           in: query
           schema:
             $ref: "#/components/schemas/ReactionType"
-          required: true
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/paginationReverse"
         - $ref: "#/components/parameters/pageToken"
@@ -1850,15 +1849,15 @@ components:
       type: string
       description: |-
         Type of interaction a user can have with content on the Farcaster network.
-        - REACTION_TYPE_LIKE: Express appreciation for the target content. Similar to "likes" or "favorites" on other platforms.
-        - REACTION_TYPE_RECAST: Share the target content with the user's followers, similar to a "retweet" or "reblog". Helps increase content visibility.
-      default: REACTION_TYPE_LIKE
+        - Like: Express appreciation for the target content. Similar to "likes" or "favorites" on other platforms.
+        - Recast: Share the target content with the user's followers, similar to a "retweet" or "reblog". Helps increase content visibility.
+      default: Like
       enum:
-        - REACTION_TYPE_LIKE
-        - REACTION_TYPE_RECAST
+        - Like
+        - Recast
       examples:
-        - "REACTION_TYPE_LIKE"
-        - "REACTION_TYPE_RECAST"
+        - "Like"
+        - "Recast"
     RevokeMessageBody:
       type: object
       properties:


### PR DESCRIPTION
## Description of the Change

Changes the OAS spec for V1/Hubs to be consistent with the new snapchain enum

## OAS Change Summary


### Endpoint Changes
- `reactionsByTarget` - `ReactionType` no longer required

### New/Updated Schemas


- `ReactionType` - Updated `ReactionType` enum scheme to be `Like` vs `REACTION_TYPE_LIKE` for each case.


## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [x] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)
