### PR TITLE
fix: add FrameV2WithFullAuthor for some frame endpoints

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1075,6 +1075,30 @@ components:
               properties:
                 html:
                   $ref: "#/components/schemas/HtmlMetadata"
+    FrameV2WithFullAuthor:
+      description: Frame v2 object with full user object
+      # copy of FrameV2 but with the author property being the full User object
+      allOf:
+        - $ref: "#/components/schemas/FrameBase"
+        - type: object
+          required:
+            - name
+            - icon
+          properties:
+            title:
+              type: string
+              description: Button title of a frame
+            manifest:
+              $ref: "#/components/schemas/FarcasterManifest"
+            author:
+              $ref: "#/components/schemas/User"
+            metadata:
+              type: object
+              required:
+                - html
+              properties:
+                html:
+                  $ref: "#/components/schemas/HtmlMetadata"
     SubscriptionTier:
       type: object
       properties:
@@ -3754,7 +3778,7 @@ components:
         frames:
           type: array
           items:
-            $ref: "#/components/schemas/FrameV2"
+            $ref: "#/components/schemas/FrameV2WithFullAuthor"
         next:
           $ref: "#/components/schemas/NextCursor"
     SendFrameNotificationsResponse:
@@ -6970,7 +6994,7 @@ paths:
                           type: array
                           description: Array of FrameV2 objects
                           items:
-                            $ref: "#/components/schemas/FrameV2"
+                            $ref: "#/components/schemas/FrameV2WithFullAuthor"
                         top_relevant_users:
                           type: array
                           description: Array of the most relevant users


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

## OAS Change Summary

<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->
This PR adds `FrameV2WithFullAuthor` to reflect what we've already been returning from any endpoint using `get_v2_users_from_fids` / `getV2UsersFromFids`

### Updated Endpoints

<!-- List any modified endpoints, describing the change and why it was made. -->

- `GET /farcaster/frame/catalog` - Updated frame author object
- `GET /farcaster/frame/relevant` - Updated frame author object

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

<!-- Add any additional information that reviewers should be aware of. -->
Couldn't make it work by extending FrameV2, as it wasn't overwriting the author object. 
