### PR TITLE
Add Go workflow and request reviews on all workflows

### DIFF
--- a/.github/workflows/oas-to-go-sdk-pr.yaml
+++ b/.github/workflows/oas-to-go-sdk-pr.yaml
@@ -12,25 +12,25 @@ jobs:
       - name: Checkout OAS repository
         uses: actions/checkout@v3
 
-      - name: Checkout rust-sdk repository
+      - name: Checkout go-sdk repository
         uses: actions/checkout@v3
         with:
-          repository: "neynarxyz/rust-sdk.git"
+          repository: "neynarxyz/go-sdk.git"
           ref: "main"
-          path: "rust-sdk"
+          path: "go-sdk"
           token: ${{ secrets.OAS_TO_SDK_FGPAT }}
           submodules: recursive
           persist-credentials: true
 
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+      - name: Setup Go
+        uses: actions/setup-go@v4
         with:
-          toolchain: stable
-          override: true
+          go-version: '1.24'
+          check-latest: true
 
-      - name: Update OAS submodule and package version in rust-sdk
+      - name: Update OAS submodule and package version in go-sdk
         run: |
-          cd rust-sdk
+          cd go-sdk
 
           # Update OAS submodule
           cd src/OAS 
@@ -71,6 +71,10 @@ jobs:
 
           # Commit updated OAS submodule
           git add .
+          if git diff --quiet && git diff --cached --quiet; then
+          echo "No changes to commit. Exiting."
+          exit 0
+          fi
           git commit -m "Update OAS submodule"
 
           # Generate code
@@ -105,6 +109,6 @@ jobs:
           curl -X POST \
             -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/neynarxyz/rust-sdk/pulls \
+            https://api.github.com/repos/neynarxyz/go-sdk/pulls \
             -d "$DATA"
         shell: bash

--- a/.github/workflows/oas-to-go-sdk-pr.yaml
+++ b/.github/workflows/oas-to-go-sdk-pr.yaml
@@ -90,13 +90,14 @@ jobs:
 
           # Push changes
           git push origin HEAD:"$BRANCH_NAME"
+          echo "PUSHED_BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
         shell: bash
 
       - name: Create Pull Request via API
         run: |
           # Check if the branch already exists on the remote
-          if ! git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
-          echo "Branch $BRANCH_NAME does not exist on the remote because there are no changes. Exiting step."
+          if [ -z "$PUSHED_BRANCH" ]; then
+          echo "no push branch xists. Exiting step."
           exit 0
           fi
           # Install jq for JSON parsing

--- a/.github/workflows/oas-to-go-sdk-pr.yaml
+++ b/.github/workflows/oas-to-go-sdk-pr.yaml
@@ -31,7 +31,8 @@ jobs:
       - name: Update OAS submodule and package version in go-sdk
         run: |
           # Get the author of the prior commit
-          AUTHOR=$(git log -1 --pretty=format:'%ae')
+          AUTHOR=$(curl -s -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
+          https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }} | jq -r '.author.login')
           cd go-sdk
 
           # Update OAS submodule
@@ -67,6 +68,11 @@ jobs:
           git checkout -b "$BRANCH_NAME"
 
           # Commit updated OAS submodule
+          if git diff --quiet; then
+            echo "No changes to commit."
+            echo "::set-output name=skip_remaining::true"
+            exit 0
+          fi
           git add .
           git commit -m "Update OAS submodule"
 
@@ -74,6 +80,11 @@ jobs:
           ./generate.sh
 
           # Commit generated files
+          if git diff --quiet; then
+            echo "No changes to commit."
+            echo "::set-output name=skip_remaining::true"
+            exit 0
+          fi
           git add .
           git commit -m "Update generated files"
 
@@ -83,6 +94,11 @@ jobs:
 
       - name: Create Pull Request via API
         run: |
+          # Check if the branch already exists on the remote
+          if ! git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+          echo "Branch $BRANCH_NAME does not exist on the remote because there are no changes. Exiting step."
+          exit 0
+          fi
           # Install jq for JSON parsing
           sudo apt-get update && sudo apt-get install -y jq
 

--- a/.github/workflows/oas-to-go-sdk-pr.yaml
+++ b/.github/workflows/oas-to-go-sdk-pr.yaml
@@ -1,9 +1,9 @@
-name: Create Pull Request in Rust SDK
+name: Create Pull Request in Go SDK
 
 on:
   push:
-    #branches:
-    #  - main
+    branches:
+      - main
 
 jobs:
   create-pull-request:
@@ -30,16 +30,12 @@ jobs:
 
       - name: Update OAS submodule and package version in go-sdk
         run: |
+          # Get the author of the prior commit
+          AUTHOR=$(git log -1 --pretty=format:'%ae')
           cd go-sdk
 
           # Update OAS submodule
-          cd src/OAS 
-          git branch -a
-          git log -1
-          git fetch origin
-          cd ../..
           git submodule update --remote src/OAS
-          ls -la src/OAS
 
           # Set Git config
           git config user.name "GitHub Actions"
@@ -65,6 +61,7 @@ jobs:
           # Export variables for use in subsequent steps
           echo "SDK_VERSION=$SDK_VERSION" >> $GITHUB_ENV
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "AUTHOR=$AUTHOR" >> $GITHUB_ENV
 
           # Create and checkout the new branch
           git checkout -b "$BRANCH_NAME"
@@ -106,9 +103,36 @@ jobs:
           echo "Creating Pull Request with data: $DATA"
 
           # Create the pull request via GitHub API
+          RESPONSE=$(curl -X POST \
+          -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/neynarxyz/go-sdk/pulls \
+          -d "$DATA")
+
+          # Extract the pull request number from the response
+          PR_NUMBER=$(echo "$RESPONSE" | jq -r '.number')
+          echo "Pull Request Number: $PR_NUMBER"
+
+          # Check if PR_NUMBER is valid
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
+          echo "Error: Failed to create pull request."
+          echo "Response: $RESPONSE"
+          exit 1
+          fi
+
+          # Prepare JSON payload for the review request
+          REVIEWERS=$(jq -n --arg reviewer "$AUTHOR" '[ $reviewer ]')
+          REVIEW_REQUEST_DATA=$(jq -n \
+          --argjson reviewers "$REVIEWERS" \
+          '{reviewers: $reviewers}')
+
+          echo "Creating Review Request with data: $REVIEW_REQUEST_DATA"
+
+          # Create the review request via GitHub API
           curl -X POST \
-            -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/neynarxyz/go-sdk/pulls \
-            -d "$DATA"
+          -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/neynarxyz/go-sdk/pulls/$PR_NUMBER/requested_reviewers \
+          -d "$REVIEW_REQUEST_DATA"
+
         shell: bash

--- a/.github/workflows/oas-to-go-sdk-pr.yaml
+++ b/.github/workflows/oas-to-go-sdk-pr.yaml
@@ -2,8 +2,8 @@ name: Create Pull Request in Go SDK
 
 on:
   push:
-    #branches:
-    #  - main
+    branches:
+      - main
 
 jobs:
   create-pull-request:
@@ -70,7 +70,6 @@ jobs:
           # Commit updated OAS submodule
           if git diff --quiet; then
             echo "No changes to commit."
-            echo "::set-output name=skip_remaining::true"
             exit 0
           fi
           git add .
@@ -82,7 +81,6 @@ jobs:
           # Commit generated files
           if git diff --quiet; then
             echo "No changes to commit."
-            echo "::set-output name=skip_remaining::true"
             exit 0
           fi
           git add .
@@ -97,8 +95,8 @@ jobs:
         run: |
           # Check if the branch already exists on the remote
           if [ -z "$PUSHED_BRANCH" ]; then
-          echo "no push branch xists. Exiting step."
-          exit 0
+            echo "no pushed branch exists. Exiting step."
+            exit 0
           fi
           # Install jq for JSON parsing
           sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/oas-to-go-sdk-pr.yaml
+++ b/.github/workflows/oas-to-go-sdk-pr.yaml
@@ -77,6 +77,8 @@ jobs:
           git add .
           git commit -m "Update generated files"
 
+          # Push changes
+          git push origin HEAD:"$BRANCH_NAME"
         shell: bash
 
       - name: Create Pull Request via API

--- a/.github/workflows/oas-to-go-sdk-pr.yaml
+++ b/.github/workflows/oas-to-go-sdk-pr.yaml
@@ -71,7 +71,7 @@ jobs:
           git commit -m "Update OAS submodule"
 
           # Generate code
-          #./generate.sh
+          ./generate.sh
 
           # Commit generated files
           git add .

--- a/.github/workflows/oas-to-go-sdk-pr.yaml
+++ b/.github/workflows/oas-to-go-sdk-pr.yaml
@@ -68,12 +68,6 @@ jobs:
 
           # Commit updated OAS submodule
           git add .
-          git diff --cached --quiet
-          if [ $? -eq 0 ]; then
-            echo "No changes to commit. Exiting."
-            echo "SHOULD_CONTINUE=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
           git commit -m "Update OAS submodule"
 
           # Generate code
@@ -81,12 +75,6 @@ jobs:
 
           # Commit generated files
           git add .
-          git diff --cached --quiet
-          if [ $? -eq 0 ]; then
-            echo "No changes to commit. Exiting."
-            echo "SHOULD_CONTINUE=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
           git commit -m "Update generated files"
 
         shell: bash

--- a/.github/workflows/oas-to-go-sdk-pr.yaml
+++ b/.github/workflows/oas-to-go-sdk-pr.yaml
@@ -2,8 +2,8 @@ name: Create Pull Request in Go SDK
 
 on:
   push:
-    branches:
-      - main
+    #branches:
+    #  - main
 
 jobs:
   create-pull-request:
@@ -68,9 +68,11 @@ jobs:
 
           # Commit updated OAS submodule
           git add .
-          if git diff --quiet && git diff --cached --quiet; then
-          echo "No changes to commit. Exiting."
-          exit 0
+          git diff --cached --quiet
+          if [ $? -eq 0 ]; then
+            echo "No changes to commit. Exiting."
+            echo "SHOULD_CONTINUE=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
           git commit -m "Update OAS submodule"
 
@@ -79,9 +81,11 @@ jobs:
 
           # Commit generated files
           git add .
-          if git diff --quiet && git diff --cached --quiet; then
-          echo "No changes to commit. Exiting."
-          exit 0
+          git diff --cached --quiet
+          if [ $? -eq 0 ]; then
+            echo "No changes to commit. Exiting."
+            echo "SHOULD_CONTINUE=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
           git commit -m "Update generated files"
 

--- a/.github/workflows/oas-to-nodejs-sdk-pr.yaml
+++ b/.github/workflows/oas-to-nodejs-sdk-pr.yaml
@@ -30,7 +30,8 @@ jobs:
       - name: Update OAS submodule and package version in nodejs-sdk
         run: |
           # Get the author of the prior commit
-          AUTHOR=$(git log -1 --pretty=format:'%ae')
+          AUTHOR=$(curl -s -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
+          https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }} | jq -r '.author.login')
           cd nodejs-sdk
 
           yarn install

--- a/.github/workflows/oas-to-nodejs-sdk-pr.yaml
+++ b/.github/workflows/oas-to-nodejs-sdk-pr.yaml
@@ -69,6 +69,10 @@ jobs:
           git checkout -b "$BRANCH_NAME"
 
           # Commit updated OAS submodule
+          if git diff --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
           git add .
           git commit -m "Update OAS submodule"
 
@@ -76,6 +80,10 @@ jobs:
           yarn generate:all
 
           # Commit generated files
+          if git diff --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
           git add .
           git commit -m "Update generated files"
 
@@ -88,10 +96,17 @@ jobs:
 
           # Push changes
           git push origin HEAD:"$BRANCH_NAME"
+          echo "PUSHED_BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
+
         shell: bash
 
       - name: Create Pull Request via API
         run: |
+          # Check if the branch already exists on the remote
+          if [ -z "$PUSHED_BRANCH" ]; then
+            echo "no pushed branch exists. Exiting step."
+            exit 0
+          fi
           # Install jq for JSON parsing
           sudo apt-get update && sudo apt-get install -y jq
 

--- a/.github/workflows/oas-to-nodejs-sdk-pr.yaml
+++ b/.github/workflows/oas-to-nodejs-sdk-pr.yaml
@@ -69,10 +69,6 @@ jobs:
 
           # Commit updated OAS submodule
           git add .
-          if git diff --quiet && git diff --cached --quiet; then
-          echo "No changes to commit. Exiting."
-          exit 0
-          fi
           git commit -m "Update OAS submodule"
 
           # Generate code
@@ -80,10 +76,6 @@ jobs:
 
           # Commit generated files
           git add .
-          if git diff --quiet && git diff --cached --quiet; then
-          echo "No changes to commit. Exiting."
-          exit 0
-          fi
           git commit -m "Update generated files"
 
           # Update package.json version

--- a/.github/workflows/oas-to-nodejs-sdk-pr.yaml
+++ b/.github/workflows/oas-to-nodejs-sdk-pr.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Update OAS submodule and package version in nodejs-sdk
         run: |
+          # Get the author of the prior commit
+          AUTHOR=$(git log -1 --pretty=format:'%ae')
           cd nodejs-sdk
 
           yarn install
@@ -60,12 +62,17 @@ jobs:
           # Export variables for use in subsequent steps
           echo "SDK_VERSION=$SDK_VERSION" >> $GITHUB_ENV
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "AUTHOR=$AUTHOR" >> $GITHUB_ENV
 
           # Create and checkout the new branch
           git checkout -b "$BRANCH_NAME"
 
           # Commit updated OAS submodule
           git add .
+          if git diff --quiet && git diff --cached --quiet; then
+          echo "No changes to commit. Exiting."
+          exit 0
+          fi
           git commit -m "Update OAS submodule"
 
           # Generate code
@@ -73,6 +80,10 @@ jobs:
 
           # Commit generated files
           git add .
+          if git diff --quiet && git diff --cached --quiet; then
+          echo "No changes to commit. Exiting."
+          exit 0
+          fi
           git commit -m "Update generated files"
 
           # Update package.json version
@@ -102,9 +113,35 @@ jobs:
           echo "Creating Pull Request with data: $DATA"
 
           # Create the pull request via GitHub API
+          RESPONSE=$(curl -X POST \
+          -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/neynarxyz/nodejs-sdk/pulls \
+          -d "$DATA")
+
+          # Extract the pull request number from the response
+          PR_NUMBER=$(echo "$RESPONSE" | jq -r '.number')
+          echo "Pull Request Number: $PR_NUMBER"
+
+          # Check if PR_NUMBER is valid
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
+          echo "Error: Failed to create pull request."
+          echo "Response: $RESPONSE"
+          exit 1
+          fi
+
+          # Prepare JSON payload for the review request
+          REVIEWERS=$(jq -n --arg reviewer "$AUTHOR" '[ $reviewer ]')
+          REVIEW_REQUEST_DATA=$(jq -n \
+          --argjson reviewers "$REVIEWERS" \
+          '{reviewers: $reviewers}')
+
+          echo "Creating Review Request with data: $REVIEW_REQUEST_DATA"
+
+          # Create the review request via GitHub API
           curl -X POST \
-            -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/neynarxyz/nodejs-sdk/pulls \
-            -d "$DATA"
+          -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/neynarxyz/nodejs-sdk/pulls/$PR_NUMBER/requested_reviewers \
+          -d "$REVIEW_REQUEST_DATA"
         shell: bash

--- a/.github/workflows/oas-to-rust-sdk-pr.yaml
+++ b/.github/workflows/oas-to-rust-sdk-pr.yaml
@@ -2,8 +2,8 @@ name: Create Pull Request in Rust SDK
 
 on:
   push:
-    #branches:
-    #  - main
+    branches:
+      - main
 
 jobs:
   create-pull-request:
@@ -30,16 +30,12 @@ jobs:
 
       - name: Update OAS submodule and package version in rust-sdk
         run: |
+          # Get the author of the prior commit
+          AUTHOR=$(git log -1 --pretty=format:'%ae')
           cd rust-sdk
 
           # Update OAS submodule
-          cd src/OAS 
-          git branch -a
-          git log -1
-          git fetch origin
-          cd ../..
           git submodule update --remote src/OAS
-          ls -la src/OAS
 
           # Set Git config
           git config user.name "GitHub Actions"
@@ -65,6 +61,7 @@ jobs:
           # Export variables for use in subsequent steps
           echo "SDK_VERSION=$SDK_VERSION" >> $GITHUB_ENV
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "AUTHOR=$AUTHOR" >> $GITHUB_ENV
 
           # Create and checkout the new branch
           git checkout -b "$BRANCH_NAME"
@@ -102,9 +99,35 @@ jobs:
           echo "Creating Pull Request with data: $DATA"
 
           # Create the pull request via GitHub API
+          RESPONSE=$(curl -X POST \
+          -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/neynarxyz/rust-sdk/pulls \
+          -d "$DATA")
+
+          # Extract the pull request number from the response
+          PR_NUMBER=$(echo "$RESPONSE" | jq -r '.number')
+          echo "Pull Request Number: $PR_NUMBER"
+
+          # Check if PR_NUMBER is valid
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
+          echo "Error: Failed to create pull request."
+          echo "Response: $RESPONSE"
+          exit 1
+          fi
+
+          # Prepare JSON payload for the review request
+          REVIEWERS=$(jq -n --arg reviewer "$AUTHOR" '[ $reviewer ]')
+          REVIEW_REQUEST_DATA=$(jq -n \
+          --argjson reviewers "$REVIEWERS" \
+          '{reviewers: $reviewers}')
+
+          echo "Creating Review Request with data: $REVIEW_REQUEST_DATA"
+
+          # Create the review request via GitHub API
           curl -X POST \
-            -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/neynarxyz/rust-sdk/pulls \
-            -d "$DATA"
+          -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/neynarxyz/rust-sdk/pulls/$PR_NUMBER/requested_reviewers \
+          -d "$REVIEW_REQUEST_DATA"
         shell: bash

--- a/.github/workflows/oas-to-rust-sdk-pr.yaml
+++ b/.github/workflows/oas-to-rust-sdk-pr.yaml
@@ -71,7 +71,7 @@ jobs:
           git commit -m "Update OAS submodule" --allow-empty
 
           # Generate code
-          #./generate.sh
+          ./generate.sh
 
           # Commit generated files
           git add .

--- a/.github/workflows/oas-to-rust-sdk-pr.yaml
+++ b/.github/workflows/oas-to-rust-sdk-pr.yaml
@@ -2,8 +2,8 @@ name: Create Pull Request in Rust SDK
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 jobs:
   create-pull-request:
@@ -70,7 +70,6 @@ jobs:
           # Commit updated OAS submodule
           if git diff --quiet; then
             echo "No changes to commit."
-            echo "::set-output name=skip_remaining::true"
             exit 0
           fi
           git add .
@@ -82,7 +81,6 @@ jobs:
           # Commit generated files
           if git diff --quiet; then
             echo "No changes to commit."
-            echo "::set-output name=skip_remaining::true"
             exit 0
           fi
           git add .
@@ -97,8 +95,8 @@ jobs:
         run: |
           # Check if the branch already exists on the remote
           if [ -z "$PUSHED_BRANCH" ]; then
-          echo "no push branch xists. Exiting step."
-          exit 0
+            echo "no pushed branch exists. Exiting step."
+            exit 0
           fi
           # Install jq for JSON parsing
           sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/oas-to-rust-sdk-pr.yaml
+++ b/.github/workflows/oas-to-rust-sdk-pr.yaml
@@ -68,15 +68,17 @@ jobs:
 
           # Commit updated OAS submodule
           git add .
-          git commit -m "Update OAS submodule"
+          git commit -m "Update OAS submodule" --allow-empty
 
           # Generate code
           #./generate.sh
 
           # Commit generated files
           git add .
-          git commit -m "Update generated files"
+          git commit -m "Update generated files" --allow-empty
 
+          # Push changes
+          git push origin HEAD:"$BRANCH_NAME"
         shell: bash
 
       - name: Create Pull Request via API

--- a/.github/workflows/oas-to-rust-sdk-pr.yaml
+++ b/.github/workflows/oas-to-rust-sdk-pr.yaml
@@ -68,6 +68,11 @@ jobs:
           git checkout -b "$BRANCH_NAME"
 
           # Commit updated OAS submodule
+          if git diff --quiet; then
+            echo "No changes to commit."
+            echo "::set-output name=skip_remaining::true"
+            exit 0
+          fi
           git add .
           git commit -m "Update OAS submodule"
 
@@ -75,15 +80,26 @@ jobs:
           ./generate.sh
 
           # Commit generated files
+          if git diff --quiet; then
+            echo "No changes to commit."
+            echo "::set-output name=skip_remaining::true"
+            exit 0
+          fi
           git add .
           git commit -m "Update generated files"
 
           # Push changes
           git push origin HEAD:"$BRANCH_NAME"
+          echo "PUSHED_BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
         shell: bash
 
       - name: Create Pull Request via API
         run: |
+          # Check if the branch already exists on the remote
+          if [ -z "$PUSHED_BRANCH" ]; then
+          echo "no push branch xists. Exiting step."
+          exit 0
+          fi
           # Install jq for JSON parsing
           sudo apt-get update && sudo apt-get install -y jq
 

--- a/.github/workflows/oas-to-rust-sdk-pr.yaml
+++ b/.github/workflows/oas-to-rust-sdk-pr.yaml
@@ -31,7 +31,8 @@ jobs:
       - name: Update OAS submodule and package version in rust-sdk
         run: |
           # Get the author of the prior commit
-          AUTHOR=$(git log -1 --pretty=format:'%ae')
+          AUTHOR=$(curl -s -H "Authorization: token ${{ secrets.OAS_TO_SDK_FGPAT }}" \
+          https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }} | jq -r '.author.login')
           cd rust-sdk
 
           # Update OAS submodule
@@ -68,14 +69,14 @@ jobs:
 
           # Commit updated OAS submodule
           git add .
-          git commit -m "Update OAS submodule" --allow-empty
+          git commit -m "Update OAS submodule"
 
           # Generate code
           ./generate.sh
 
           # Commit generated files
           git add .
-          git commit -m "Update generated files" --allow-empty
+          git commit -m "Update generated files"
 
           # Push changes
           git push origin HEAD:"$BRANCH_NAME"

--- a/.github/workflows/oas-to-rust-sdk-pr.yaml
+++ b/.github/workflows/oas-to-rust-sdk-pr.yaml
@@ -68,12 +68,6 @@ jobs:
 
           # Commit updated OAS submodule
           git add .
-          git diff --cached --quiet
-          if [ $? -eq 0 ]; then
-            echo "No changes to commit. Exiting."
-            echo "SHOULD_CONTINUE=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
           git commit -m "Update OAS submodule"
 
           # Generate code
@@ -81,12 +75,6 @@ jobs:
 
           # Commit generated files
           git add .
-          git diff --cached --quiet
-          if [ $? -eq 0 ]; then
-            echo "No changes to commit. Exiting."
-            echo "SHOULD_CONTINUE=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
           git commit -m "Update generated files"
 
         shell: bash

--- a/.github/workflows/oas-to-rust-sdk-pr.yaml
+++ b/.github/workflows/oas-to-rust-sdk-pr.yaml
@@ -2,8 +2,8 @@ name: Create Pull Request in Rust SDK
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 jobs:
   create-pull-request:
@@ -68,6 +68,12 @@ jobs:
 
           # Commit updated OAS submodule
           git add .
+          git diff --cached --quiet
+          if [ $? -eq 0 ]; then
+            echo "No changes to commit. Exiting."
+            echo "SHOULD_CONTINUE=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           git commit -m "Update OAS submodule"
 
           # Generate code
@@ -75,9 +81,11 @@ jobs:
 
           # Commit generated files
           git add .
-          if git diff --quiet && git diff --cached --quiet; then
-          echo "No changes to commit. Exiting."
-          exit 0
+          git diff --cached --quiet
+          if [ $? -eq 0 ]; then
+            echo "No changes to commit. Exiting."
+            echo "SHOULD_CONTINUE=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
           git commit -m "Update generated files"
 


### PR DESCRIPTION
As requested, workflows now request reviews from the latest OAS committer. Additionally, workflows exit cleanly if there are no diffs.

I've validated that PRs are generating when diffs exists and the workflow exits successfully wihout creating PRs when they don't.

The reviewer is chosen as the author of the branch HEAD. the action looks up the username and posts a review request for them.

n.b. it might be more maintainable to utilize the github cli, since it obviates all the jq formatting
