### PR TITLE
export SDK_VERSION to generate script

### DIFF
--- a/.github/workflows/oas-to-go-sdk-pr.yaml
+++ b/.github/workflows/oas-to-go-sdk-pr.yaml
@@ -76,6 +76,7 @@ jobs:
           git commit -m "Update OAS submodule"
 
           # Generate code
+          export SDK_VERSION
           ./generate.sh
 
           # Commit generated files

--- a/.github/workflows/oas-to-rust-sdk-pr.yaml
+++ b/.github/workflows/oas-to-rust-sdk-pr.yaml
@@ -76,6 +76,7 @@ jobs:
           git commit -m "Update OAS submodule"
 
           # Generate code
+          export SDK_VERSION
           ./generate.sh
 
           # Commit generated files


### PR DESCRIPTION
the rust and go scripts rely on this to populate the packaging with the
correct versioning for publishing.
