### PR TITLE
Add /farcaster/frame/search endpoint

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -7410,6 +7410,44 @@ paths:
                   $ref: "#/components/schemas/NeynarFrame"
         "404":
           $ref: "#/components/responses/404Response"
+  /farcaster/frame/search:
+    get:
+      tags:
+        - Frame
+      summary: Search mini apps
+      description: Search for mini apps based on a query string
+      externalDocs:
+        url: https://docs.neynar.com/reference/search-frames
+      operationId: search-frames
+      parameters:
+        - name: q
+          in: query
+          description: Query string to search for mini apps
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Number of results to fetch
+          required: false
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+          x-is-limit-param: true
+        - name: cursor
+          in: query
+          description: Pagination cursor
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FrameCatalogResponse"
   /farcaster/frame/crawl:
     get:
       tags:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.4
 info:
   title: Farcaster API V2
-  version: 2.39.0
+  version: 2.40.0
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol. See
     the [Neynar docs](https://docs.neynar.com/reference) for more details.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.4
 info:
   title: Farcaster API V2
-  version: 2.38.1
+  version: 2.39.1
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol. See
     the [Neynar docs](https://docs.neynar.com/reference) for more details.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -7448,6 +7448,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FrameCatalogResponse"
+        "400":
+          $ref: "#/components/responses/400Response"
   /farcaster/frame/crawl:
     get:
       tags:


### PR DESCRIPTION
## Description of the Change

Add new endpoint `/farcaster/frame/search` for NEYN-4888

## OAS Change Summary


### New Endpoints

GET `/farcaster/frame/search` - search frames by simple text search across name, description and tags


## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [x] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

<!-- Add any additional information that reviewers should be aware of. -->
