### PR TITLE
feat: broadcast notification filters

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1816,7 +1816,7 @@ components:
           minimum: -180
           maximum: 180
         radius:
-          type: number          format: double
+          type: number
           minimum: 0
         address:
           $ref: "#/components/schemas/LocationAddress"

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1815,6 +1815,8 @@ components:
         radius:
           type: number
           minimum: 0
+          description: >-
+            The radius in meters for the location search. Any location within this radius will be returned.
         address:
           $ref: "#/components/schemas/LocationAddress"
     User:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1428,30 +1428,32 @@ components:
                 An optional UUID for the notification, used as an idempotency
                 key.
               example: 123e4567-e89b-12d3-a456-426614174000
-        exclude_fids:
-          type: array
-          items:
-            $ref: "#/components/schemas/Fid"
+        filters:
+          type: object
           description: >-
-            An optional array of FIDs to exclude from the notification.
-        following_fid:
-          $ref: "#/components/schemas/Fid"
-          description: >-
-            An optional FID to check if the user is following the target FID.
-            If true, the notification will only be sent to users following the
-            specified FID.
-        min_user_score:
-          type: number
-          minimum: 0
-          maximum: 1
-          description: >-
-            An optional minimum user score to filter notifications so that only
-            users with a higher score are notified.
-        location:
-          $ref: "#/components/schemas/Location"
-          description: >-
-            An optional location to filter notifications so that only notifications
-            within a certain distance of the location are sent.
+            Filters to apply to the target_fids set. All filters are additive,
+            so only users matching all filters will be notified.
+          properties:
+            exclude_fids:
+              type: array
+              items:
+                $ref: "#/components/schemas/Fid"
+              description: >-
+                Only send notifications to users who are not in the given FIDs.
+            following_fid:
+              $ref: "#/components/schemas/Fid"
+              description: >-
+                Only send notifications to users following the given FID.
+            minimum_user_score:
+              type: number
+              minimum: 0
+              maximum: 1
+              description: >-
+                Only send notifications to users with a score greater than or equal to this value.
+            near_location:
+              $ref: "#/components/schemas/Location"
+              description: >-
+                Only send notifications to users near the given location.
     RemoveChannelMemberReqBody:
       type: object
       required:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1385,8 +1385,8 @@ components:
           maxItems: 100
           description: >-
             An array of target FIDs to whom the notifications should be sent.
-            Each FID must be a positive integer, with a maximum of 100 FIDs
-            allowed per call.
+            Each FID must be a positive integer. Pass an empty array to send
+            notifications to all FIDs with notifications enabled for the mini app.
           example:
             - 1
             - 2
@@ -1429,6 +1429,30 @@ components:
                 An optional UUID for the notification, used as an idempotency
                 key.
               example: 123e4567-e89b-12d3-a456-426614174000
+        exclude_fids:
+          type: array
+          items:
+            $ref: "#/components/schemas/Fid"
+          description: >-
+            An optional array of FIDs to exclude from the notification.
+        following_fid:
+          $ref: "#/components/schemas/Fid"
+          description: >-
+            An optional FID to check if the user is following the target FID.
+            If true, the notification will only be sent to users following the
+            specified FID.
+        min_user_score:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: >-
+            An optional minimum user score to filter notifications so that only
+            users with a higher score are notified.
+        location:
+          $ref: "#/components/schemas/Location"
+          description: >-
+            An optional location to filter notifications so that only notifications
+            within a certain distance of the location are sent.
     RemoveChannelMemberReqBody:
       type: object
       required:
@@ -1791,6 +1815,9 @@ components:
           format: double
           minimum: -180
           maximum: 180
+        radius:
+          type: number          format: double
+          minimum: 0
         address:
           $ref: "#/components/schemas/LocationAddress"
     User:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.4
 info:
   title: Farcaster API V2
-  version: 2.40.0
+  version: 2.41.0
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol. See
     the [Neynar docs](https://docs.neynar.com/reference) for more details.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1442,8 +1442,6 @@ components:
                 Only send notifications to users who are not in the given FIDs.
             following_fid:
               $ref: "#/components/schemas/Fid"
-              description: >-
-                Only send notifications to users following the given FID.
             minimum_user_score:
               type: number
               minimum: 0
@@ -1452,8 +1450,6 @@ components:
                 Only send notifications to users with a score greater than or equal to this value.
             near_location:
               $ref: "#/components/schemas/Location"
-              description: >-
-                Only send notifications to users near the given location.
     RemoveChannelMemberReqBody:
       type: object
       required:
@@ -8167,6 +8163,16 @@ paths:
                 target_url: >-
                   https://domain-of-your-frame.com/the-page-on-which-the-user-should-land
                 uuid: 9cb07cfe-1130-48b3-a245-5dd153ced3a3
+              filters:
+                exclude_fids:
+                  - 2
+                  - 8988
+                following_fid: 3
+                minimum_user_score: 0.5
+                near_location:
+                  latitude: 37.774929
+                  longitude: -122.419418
+                  radius: 1000
       responses:
         "200":
           description: Successful operation.


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

## OAS Change Summary

<!-- List out the specific OAS changes. For example, new/updated endpoints, parameters, response codes, schemas, etc. -->
Added notification filters for `POST /farcaster/frame/notification`, related to this [monorepo PR](https://github.com/neynarxyz/monorepo/pull/1815).

### New Endpoints

<!-- List any new endpoints added, along with their method, path, and a brief description. -->

- `POST /new/endpoint` - Description of the new endpoint.

### Updated Endpoints

<!-- List any modified endpoints, describing the change and why it was made. -->

- `GET /existing/endpoint` - Updated description, parameters, or responses.

### Deprecated Endpoints

<!-- List any endpoints that are now deprecated. -->

- `DELETE /old/endpoint` - Marked for deprecation due to [reason].

### New/Updated Schemas

<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->

- `NewSchema` - Schema for a new resource.
- `UpdatedSchema` - Modified to include additional fields.

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [ ] I have validated that all new/updated endpoints conform to OAS standards.
- [ ] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

<!-- Add any additional information that reviewers should be aware of. -->
