### PR TITLE
fix: make time_window defaults route specific

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -60,7 +60,6 @@ components:
       example: 3
     TrendingTimeWindow:
       type: string
-      default: 24h
       enum:
         - 1h
         - 6h
@@ -6917,6 +6916,7 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/TrendingTimeWindow"
+            default: 24h
           example: 24h
         - name: channel_id
           in: query
@@ -7294,6 +7294,7 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/TrendingTimeWindow"
+            default: 7d
         - name: categories
           in: query
           description: >-
@@ -7356,6 +7357,7 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/TrendingTimeWindow"
+            default: 7d
       responses:
         "200":
           description: Successful response

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -6915,8 +6915,10 @@ paths:
           description: Time window for trending casts (7d window for channel feeds only)
           required: false
           schema:
-            $ref: "#/components/schemas/TrendingTimeWindow"
-            default: 24h
+            allOf:
+              - $ref: "#/components/schemas/TrendingTimeWindow"
+              - type: string
+                default: 24h
           example: 24h
         - name: channel_id
           in: query
@@ -7293,8 +7295,10 @@ paths:
             mini app, used to sort mini app results
           required: false
           schema:
-            $ref: "#/components/schemas/TrendingTimeWindow"
-            default: 7d
+            allOf:
+              - $ref: "#/components/schemas/TrendingTimeWindow"
+              - type: string
+                default: 7d
         - name: categories
           in: query
           description: >-
@@ -7356,8 +7360,10 @@ paths:
             relevance
           required: false
           schema:
-            $ref: "#/components/schemas/TrendingTimeWindow"
-            default: 7d
+            allOf:
+              - $ref: "#/components/schemas/TrendingTimeWindow"
+              - type: string
+                default: 7d
       responses:
         "200":
           description: Successful response


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->
This PR moves the default value out of `TrendingTimeWindow` and into each route that uses it.

### Updated Endpoints

<!-- List any modified endpoints, describing the change and why it was made. -->

- `GET /frame/catalog` - Updated default time_window to 7d
- `GET /frame/relevant` - Updated default time_window to 7d

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [ ] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)
