### PR TITLE
fix: move default to time window

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -58,7 +58,7 @@ components:
       format: int32
       description: The unique identifier of a farcaster user (unsigned integer)
       example: 3
-    TrendingTimeWindow:
+    MiniAppTimeWindow:
       type: string
       enum:
         - 1h
@@ -66,7 +66,9 @@ components:
         - 12h
         - 24h
         - 7d
-      description: Time window for trending content
+      default: 7d
+      example: 7d
+      description: Time window for mini app analytics
     ChannelId:
       type: string
       description: The unique identifier of a farcaster channel
@@ -6948,11 +6950,16 @@ paths:
           description: Time window for trending casts (7d window for channel feeds only)
           required: false
           schema:
-            allOf:
-              - $ref: "#/components/schemas/TrendingTimeWindow"
-              - type: string
-                default: 24h
-          example: 24h
+            type: string
+            enum:
+              - 1h
+              - 6h
+              - 12h
+              - 24h
+              - 7d
+            default: 24h
+            example: 24h
+            description: Time window for trending content
         - name: channel_id
           in: query
           description: >-
@@ -7328,10 +7335,7 @@ paths:
             mini app, used to sort mini app results
           required: false
           schema:
-            allOf:
-              - $ref: "#/components/schemas/TrendingTimeWindow"
-              - type: string
-                default: 7d
+            $ref: "#/components/schemas/MiniAppTimeWindow"
         - name: categories
           in: query
           description: >-
@@ -7393,10 +7397,7 @@ paths:
             relevance
           required: false
           schema:
-            allOf:
-              - $ref: "#/components/schemas/TrendingTimeWindow"
-              - type: string
-                default: 7d
+            $ref: "#/components/schemas/MiniAppTimeWindow"
       responses:
         "200":
           description: Successful response


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->
This PR fixes [this build failure](https://github.com/neynarxyz/OAS/actions/runs/15033575361/job/42251036097) by moving the default value back to the time window component, and renaming it for mini-app specific use. The former `TrendingTimeWindow` as used by the trending feed endpoint has been moved to the route definition, as it only had one use.

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [ ] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

<!-- Add any additional information that reviewers should be aware of. -->
