### PR TITLE
Clarify target param of POST /farcaster/reaction to be either hash or…

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -2412,7 +2412,16 @@ components:
         reaction_type:
           $ref: "#/components/schemas/ReactionType"
         target:
-          type: string
+            description: Target cast hash (hex string starting with 0x) or a valid URL.
+            oneOf:
+            - type: string
+              pattern: '^0x[a-fA-F0-9]{40}$'
+              example: "0x3702ec1b298bb7ac6f00346432d959ad7b05b9a8"
+              description: Cast hash (hex string starting with 0x)
+            - type: string
+              format: uri
+              example: "https://neynar.com"
+              description: URL
         target_author_fid:
           $ref: "#/components/schemas/Fid"
         idem:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.4
 info:
   title: Farcaster API V2
-  version: 2.41.0
+  version: 2.41.1
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol. See
     the [Neynar docs](https://docs.neynar.com/reference) for more details.


### PR DESCRIPTION
… url

## Description of the Change
Clarified the "target" param to be *either* url or 0x hash in the /farcaster /reaction endpoints

https://github.com/user-attachments/assets/4e13c54f-52f7-446f-b365-a4dd32862c3d

### Updated Endpoints

<!-- List any modified endpoints, describing the change and why it was made. -->

POST /farcaster/reaction
DELETE /farcaster/reaction


### Deprecated Endpoints

<!-- List any endpoints that are now deprecated. -->

- `DELETE /old/endpoint` - Marked for deprecation due to [reason].

### New/Updated Schemas

<!-- List any changes to request/response schemas. Include newly added or modified schema definitions. -->

- `#/components/schemas/ReactionReqBody` - Modified target param

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

<!-- Add any additional information that reviewers should be aware of. -->
