### PR TITLE
changing description for param that was confusing to users

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -8177,7 +8177,9 @@ paths:
             maximum: 100
           x-is-limit-param: true
         - name: fids
-          description: Comma separated list of FIDs, up to 100 at a time
+          description: Comma separated list of FIDs, up to 100 at a time. 
+            If you pass in FIDs, you will get back the notification tokens for those FIDs. 
+            If you don't pass in FIDs, you will get back all the notification tokens for the mini app.
           in: query
           required: false
           example: 194, 191, 6131


### PR DESCRIPTION
change to `fids` param description on this api: https://api.neynar.com/v2/farcaster/frame/notification_tokens