### PR TITLE
Update POST /reactions spec for target property to avoid using oneOf

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -2523,16 +2523,11 @@ components:
         reaction_type:
           $ref: "#/components/schemas/ReactionType"
         target:
-          description: Target cast hash (hex string starting with 0x) or a valid URL.
-          oneOf:
-            - type: string
-              pattern: "^0x[a-fA-F0-9]{40}$"
-              example: "0x3702ec1b298bb7ac6f00346432d959ad7b05b9a8"
-              description: Cast hash (hex string starting with 0x)
-            - type: string
-              format: uri
-              example: "https://neynar.com"
-              description: URL
+          type: string
+          description: Target cast hash (hex string starting with 0x) OR a valid URL.
+          example: >-
+            0x3702ec1b298bb7ac6f00346432d959ad7b05b9a8
+            -OR- http://neynar.com/
         target_author_fid:
           $ref: "#/components/schemas/Fid"
         idem:
@@ -7707,10 +7702,25 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/ReactionReqBody"
-            example:
-              signer_uuid: 19d0c5fd-9b33-4a48-a0e2-bc7b0555baec
-              target: "0x1ea99cbed57e4020314ba3fadd7c692d2de34d5f"
-              reaction_type: like
+            examples:
+              "Like Cast Example":
+                summary: Example like with cast hash
+                value:
+                  signer_uuid: "19d0c5fd-9b33-4a48-a0e2-bc7b0555baec"
+                  reaction_type: "like"
+                  target: "0x3702ec1b298bb7ac6f00346432d959ad7b05b9a8"
+              "Recast Example":
+                summary: Example recast with cast hash
+                value:
+                  signer_uuid: "19d0c5fd-9b33-4a48-a0e2-bc7b0555baec"
+                  reaction_type: "recast"
+                  target: "0x3702ec1b298bb7ac6f00346432d959ad7b05b9a8"
+              "Like URL Example":
+                summary: Example like with URL
+                value:
+                  signer_uuid: "19d0c5fd-9b33-4a48-a0e2-bc7b0555baec"
+                  reaction_type: "like"
+                  target: "https://example.com/123"
       responses:
         "200":
           description: Successful operation.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.4
 info:
   title: Farcaster API V2
-  version: 2.43.1
+  version: 2.43.2
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol. See
     the [Neynar docs](https://docs.neynar.com/reference) for more details.


### PR DESCRIPTION
## Description of the Change

go/rust SDK generation has poor support for `oneOf` so this PR is attempting to remove the latest offense.  The target param is just a string with an example that includes both types.  Also added multiple service-level examples that show up in the sample curl box, which is kinda nice?

## OAS Change Summary

### Updated Endpoints

changed spec of target param in:
- POST /farcaster/reaction -
- DELETE /farcaster/reaction

### New/Updated Schemas

- #/components/schemas/ReactionReqBody - Modified target param

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [ ] I have validated that all new/updated endpoints conform to OAS standards.
- [ ] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

<img width="468" alt="image" src="https://github.com/user-attachments/assets/9434e830-c88b-46df-8ccd-dfe70193f091" />

