### PR TITLE
feat: add 90d & 180d intervals to cast metrics

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -2151,7 +2151,7 @@ components:
         - solana
     Network:
       type: string
-      description: A blockchain network e.g. "ethereum", "optimism", "base", "arbitrum" 
+      description: A blockchain network e.g. "ethereum", "optimism", "base", "arbitrum"
       enum:
         - ethereum
         - optimism
@@ -6343,14 +6343,15 @@ paths:
           in: query
           required: false
           description: >-
-            Interval of time for which to fetch metrics. Choices are `1d`, `7d`,
-            `30d`
+            Interval of time for which to fetch metrics. Default is 30d.
           schema:
             type: string
             enum:
               - 1d
               - 7d
               - 30d
+              - 90d
+              - 180d
         - name: author_fid
           in: query
           required: false
@@ -8336,8 +8337,8 @@ paths:
             maximum: 100
           x-is-limit-param: true
         - name: fids
-          description: Comma separated list of FIDs, up to 100 at a time. 
-            If you pass in FIDs, you will get back the notification tokens for those FIDs. 
+          description: Comma separated list of FIDs, up to 100 at a time.
+            If you pass in FIDs, you will get back the notification tokens for those FIDs.
             If you don't pass in FIDs, you will get back all the notification tokens for the mini app.
           in: query
           required: false
@@ -9786,7 +9787,7 @@ paths:
               value: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
         - name: network
           in: query
-          required: true          
+          required: true
           schema:
             $ref: "#/components/schemas/FungibleOwnerRelevantNetwork"
           description: >-


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->

Add new options for cast metrics intervals: 90d and 180d.

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [x] I have updated or added necessary schema definitions.
- [x] I have ensured that the new schema I have added doesn't exist.
- [x] I have added description wherever necessary.
- [x] I have ensured that endpoint's responses are correct.
- [x] I have considered backward compatibility with previous versions of the API.
- [x] I have communicated any breaking changes to the appropriate stakeholders.
- [ ] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

