### PR TITLE
add new routes for notification open tracking [NEYN-5381]

### DIFF
--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.4
 info:
   title: Farcaster API V2
-  version: 2.44.0
+  version: 2.45.0
   description: >
     The Farcaster API allows you to interact with the Farcaster protocol. See
     the [Neynar docs](https://docs.neynar.com/reference) for more details.

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -8525,52 +8525,6 @@ paths:
           $ref: "#/components/responses/400Response"
         "500":
           $ref: "#/components/responses/500Response"
-  /farcaster/frame/notifications/open:
-    post:
-      tags:
-        - Frame
-      summary: Mark notification as opened
-      description: |
-        Records an event indicating that a specific notification has been opened
-        by a recipient for a given application. This increments the open count
-        and updates timestamps for the notification campaign.
-      operationId: mark-notification-opened
-      requestBody:
-        description: Notification open event details
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - campaign_id
-                - fid
-                - app_fid
-              properties:
-                campaign_id:
-                  type: string
-                  format: ulid
-                  description: The ULID of the notification campaign that was opened.
-                fid:
-                  type: integer
-                  format: int32
-                  description: The Farcaster ID (FID) of the recipient who opened the notification.
-                app_fid:
-                  type: integer
-                  format: int32
-                  description: The ID of the Farcaster client application through which the notification was opened.
-      responses:
-        "200":
-          description: Notification successfully marked as opened.
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: OK
-        "400":
-          $ref: "#/components/responses/400Response"
-        "500":
-          $ref: "#/components/responses/500Response"
   /farcaster/frame/transaction/pay:
     post:
       tags:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -73,6 +73,11 @@ components:
       format: int32
       description: The unique identifier of a farcaster user (unsigned integer)
       example: 3
+    AppFid:
+      type: integer
+      format: int32
+      description: The unique identifier of a farcaster client app
+      example: 9152
     MiniAppTimeWindow:
       type: string
       enum:
@@ -4055,6 +4060,8 @@ components:
             - token_not_found
             - token_disabled
             - failed
+        appFid:
+          $ref: "#/components/schemas/AppFid"
     ValidateFrameActionResponse:
       type: object
       required:
@@ -8412,6 +8419,144 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/ZodError"
                   - $ref: "#/components/schemas/ErrorRes"
+        "500":
+          $ref: "#/components/responses/500Response"
+    get:
+      tags:
+        - Frame
+      summary: Get notification stats
+      description: Retrieve notification delivery and opened stats for notification campaigns
+      operationId: get-notification-stats
+      parameters:
+        - name: campaign_id
+          in: query
+          required: false
+          description: An ID of a specific notification campaign to query
+          schema:
+            type: string
+            format: ulid
+        - name: limit
+          in: query
+          required: false
+          description: The number of results to return
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+          x-is-limit-param: true
+        - name: cursor
+          in: query
+          required: false
+          description: Pagination cursor
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  notificationCampaigns:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: ulid
+                          description: The unique identifier for the notification campaign.
+                        appUuid:
+                          type: string
+                          format: uuid
+                          description: The UUID of the application associated with the campaign.
+                        intendedRecipientNotificationTokenCount:
+                          type: integer
+                          format: int32
+                          description: The total number of notification tokens for intended recipients.
+                        intendedRecipientAppFids:
+                          type: array
+                          items:
+                            type: integer
+                            format: int32
+                          description: An array of Farcaster FIDs of intended recipient applications.
+                        title:
+                          type: string
+                          description: The title of the notification campaign.
+                        body:
+                          type: string
+                          description: The body text of the notification.
+                        createdAt:
+                          type: string
+                          format: date-time
+                          description: The timestamp when the campaign was created.
+                        successfulSends:
+                          type: integer
+                          format: int32
+                          description: The number of notifications successfully sent.
+                        totalOpens:
+                          type: integer
+                          format: int32
+                          description: The total number of times notifications from this campaign have been opened.
+                        totalOpensByAppFid:
+                          type: object
+                          additionalProperties:
+                            type: integer
+                            format: int32
+                          description: A record mapping app FIDs (as strings) to the number of opens for that app.
+                        uniqueOpens:
+                          type: integer
+                          format: int32
+                          description: The number of unique recipients who opened a notification from this campaign.
+                  next:
+                    $ref: "#/components/schemas/NextCursor"
+        "400":
+          $ref: "#/components/responses/400Response"
+        "500":
+          $ref: "#/components/responses/500Response"
+  /farcaster/frame/notifications/open:
+    post:
+      tags:
+        - Frame
+      summary: Mark notification as opened
+      description: |
+        Records an event indicating that a specific notification has been opened
+        by a recipient for a given application. This increments the open count
+        and updates timestamps for the notification campaign.
+      operationId: mark-notification-opened
+      requestBody:
+        description: Notification open event details
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - campaign_id
+                - fid
+                - app_fid
+              properties:
+                campaign_id:
+                  type: string
+                  format: ulid
+                  description: The ULID of the notification campaign that was opened.
+                fid:
+                  type: integer
+                  format: int32
+                  description: The Farcaster ID (FID) of the recipient who opened the notification.
+                app_fid:
+                  type: integer
+                  format: int32
+                  description: The ID of the Farcaster client application through which the notification was opened.
+      responses:
+        "200":
+          description: Notification successfully marked as opened.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: OK
         "500":
           $ref: "#/components/responses/500Response"
   /farcaster/frame/transaction/pay:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -4060,7 +4060,7 @@ components:
             - token_not_found
             - token_disabled
             - failed
-        appFid:
+        app_fid:
           $ref: "#/components/schemas/AppFid"
     ValidateFrameActionResponse:
       type: object
@@ -8424,9 +8424,9 @@ paths:
     get:
       tags:
         - Frame
-      summary: Get notification stats
+      summary: Get notification campaign stats
       description: Retrieve notification delivery and opened stats for notification campaigns
-      operationId: get-notification-stats
+      operationId: get-notification-campaign-stats
       parameters:
         - name: campaign_id
           in: query
@@ -8467,48 +8467,58 @@ paths:
                           type: string
                           format: ulid
                           description: The unique identifier for the notification campaign.
-                        appUuid:
-                          type: string
-                          format: uuid
-                          description: The UUID of the application associated with the campaign.
-                        intendedRecipientNotificationTokenCount:
-                          type: integer
-                          format: int32
-                          description: The total number of notification tokens for intended recipients.
-                        intendedRecipientAppFids:
-                          type: array
-                          items:
-                            type: integer
-                            format: int32
-                          description: An array of Farcaster FIDs of intended recipient applications.
                         title:
                           type: string
                           description: The title of the notification campaign.
                         body:
                           type: string
                           description: The body text of the notification.
-                        createdAt:
+                        created_at:
                           type: string
                           format: date-time
-                          description: The timestamp when the campaign was created.
-                        successfulSends:
-                          type: integer
-                          format: int32
-                          description: The number of notifications successfully sent.
-                        totalOpens:
-                          type: integer
-                          format: int32
-                          description: The total number of times notifications from this campaign have been opened.
-                        totalOpensByAppFid:
+                        stats:
                           type: object
-                          additionalProperties:
-                            type: integer
-                            format: int32
-                          description: A record mapping app FIDs (as strings) to the number of opens for that app.
-                        uniqueOpens:
-                          type: integer
-                          format: int32
-                          description: The number of unique recipients who opened a notification from this campaign.
+                          properties:
+                            intended_recipient_notification_token_count:
+                              type: integer
+                              format: int32
+                              description: The total number of notification tokens for intended recipients.
+                            intended_recipient_app_fids:
+                              type: array
+                              items:
+                                type: integer
+                                format: int32
+                              description: An array of Farcaster FIDs of intended recipient applications.
+                            successful_sends:
+                              type: integer
+                              format: int32
+                              description: The number of notifications successfully sent.
+                            successful_sends_by_app_fid:
+                              type: object
+                              additionalProperties:
+                                type: integer
+                                format: int32
+                              description: A record mapping app FIDs (as strings) to the number of successful sends for that app.
+                            total_opens:
+                              type: integer
+                              format: int32
+                              description: The total number of times notifications from this campaign have been opened.
+                            total_opens_by_app_fid:
+                              type: object
+                              additionalProperties:
+                                type: integer
+                                format: int32
+                              description: A record mapping app FIDs (as strings) to the number of opens for that app.
+                            unique_opens:
+                              type: integer
+                              format: int32
+                              description: The number of unique recipients who opened a notification from this campaign.
+                            unique_opens_by_app_fid:
+                              type: object
+                              additionalProperties:
+                                type: integer
+                                format: int32
+                              description: A record mapping app FIDs (as strings) to the number of unique opens for that app.
                   next:
                     $ref: "#/components/schemas/NextCursor"
         "400":

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -8557,6 +8557,8 @@ paths:
               schema:
                 type: string
                 example: OK
+        "400":
+          $ref: "#/components/responses/400Response"
         "500":
           $ref: "#/components/responses/500Response"
   /farcaster/frame/transaction/pay:

--- a/src/v2/spec.yaml
+++ b/src/v2/spec.yaml
@@ -71,13 +71,8 @@ components:
     Fid:
       type: integer
       format: int32
-      description: The unique identifier of a farcaster user (unsigned integer)
+      description: The unique identifier of a farcaster user or app (unsigned integer)
       example: 3
-    AppFid:
-      type: integer
-      format: int32
-      description: The unique identifier of a farcaster client app
-      example: 9152
     MiniAppTimeWindow:
       type: string
       enum:
@@ -4061,7 +4056,7 @@ components:
             - token_disabled
             - failed
         app_fid:
-          $ref: "#/components/schemas/AppFid"
+          $ref: "#/components/schemas/Fid"
     ValidateFrameActionResponse:
       type: object
       required:


### PR DESCRIPTION
## Description of the Change

<!-- Provide a concise description of the changes made to the OpenAPI Specification in this pull request. -->
This PR adds new routes for tracking notification opens and getting related statistics.

### New Endpoints

<!-- List any new endpoints added, along with their method, path, and a brief description. -->

- `GET /farcaster/frame/notifications` - Get stats for one or more notification campaigns.

## Checklist

<!-- Ensure that the following items have been addressed before submitting the pull request. -->

- [x] I have validated that all new/updated endpoints conform to OAS standards.
- [ ] I have updated or added necessary schema definitions.
- [ ] I have ensured that the new schema I have added doesn't exist.
- [ ] I have added description wherever necessary.
- [ ] I have ensured that endpoint's responses are correct.
- [ ] I have considered backward compatibility with previous versions of the API.
- [ ] I have communicated any breaking changes to the appropriate stakeholders.
- [x] I have tested the OAS changes using a tool like [Swagger editor](https://editor-next.swagger.io/?_gl=1*ad75lu*_gcl_au*MjA3NjEyNzk1Mi4xNzMzNDM5MDcw)

## Additional Comments

<!-- Add any additional information that reviewers should be aware of. -->
