### PR TITLE
feat: add workflow_dispatch and repository_dispatch triggers to enabl…

### DIFF
--- a/.github/workflows/oas-to-nodejs-sdk-repo.yaml
+++ b/.github/workflows/oas-to-nodejs-sdk-repo.yaml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: false
+        default: 'Manual trigger'
+  repository_dispatch:
+    types: [oas-updated]
 
 jobs:
   update-sdk:


### PR DESCRIPTION
…e automated workflow execution

- Add workflow_dispatch trigger for manual workflow execution via GitHub UI
- Add repository_dispatch trigger with 'oas-updated' event type for automated triggering from monorepo
- Solves issue where commits pushed with GITHUB_TOKEN don't trigger downstream workflows
- Monorepo can now send API call to trigger workflow chain after pushing OAS updates

<!-- Note: src/api/spec.yaml is now auto-generated. Do not make manual changes to it. PRs should only be made against this repo to change other things, like the src/hub-api/spec.yaml file or Github Actions workflows. -->