### PR TITLE
docs: deprecate GET /v2/farcaster/channel/search

### DIFF
--- a/src/api/spec.yaml
+++ b/src/api/spec.yaml
@@ -2322,7 +2322,8 @@ paths:
         - Channel
   /v2/farcaster/channel/search/:
     get:
-      description: Returns a list of channels based on ID or name
+      deprecated: true
+      description: 'Returns a list of channels based on ID or name DEPRECATED: this endpoint is non-functional and returns an empty response; it will be removed in a future release. Use /v2/farcaster/channel/bulk to look up channels by ID.'
       externalDocs:
         url: https://docs.neynar.com/reference/search-channels
       operationId: search-channels


### PR DESCRIPTION
Marks `GET /v2/farcaster/channel/search` as `deprecated: true` in the spec, same operation-level convention as `login/authorize`.

Context: the route is a dead stub returning `{}` (pre-existing, predates the search migration). Traffic is ~94 req/48h and every caller already receives an empty 200, so this documents reality rather than changing behavior. Description points to `channel/bulk` for channel-ID lookups.

Propagates automatically to the Mintlify docs and Node SDK on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)